### PR TITLE
mapToProps: support new `observe` key for Observables

### DIFF
--- a/docs/api/mapToProps.md
+++ b/docs/api/mapToProps.md
@@ -133,3 +133,38 @@ export default mapToProps({
   }
 })(MyComponent);
 ```
+
+## Observe
+
+The `observe` key can be used for listening to an observable, and then map its returned object as props.
+
+You have access to the `app` instance, leaving you free to get observables from other Factories or Services if need be
+
+```js
+import { Observable } from 'rxjs';
+
+export default mapToProps({
+  observe: (app) => {
+    return Observable
+      // iterate over these values in a sequence
+      .of(1, 2)
+
+      // now convert it to an object, which will be available as props
+      .scan(
+        // this function would be called twice,
+        // first with `1`, and then `2` as number
+        (props, number) => {
+          props.total = props.total + number;
+
+          return acc;
+        },
+
+        // the initial object to start the `scan` with
+        {
+          appId: app.getOption('appId'),
+          total: 0
+        }
+      );
+  }
+})(RootComponent);
+```

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "redux": "^3.5.2",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.1.0",
-    "rxjs": "^5.0.0-beta.10"
+    "rxjs": "^5.0.0-rc.1"
   },
   "devDependencies": {
     "alex": "^3.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Model from './Model';
 import PropTypes from './PropTypes';
 import Region from './components/Region';
 import render from './render';
+import isObservable from './utils/isObservable';
 
 export default {
   combineReducers,
@@ -23,4 +24,5 @@ export default {
   PropTypes,
   Region,
   render,
+  isObservable,
 };

--- a/src/utils/isObservable.js
+++ b/src/utils/isObservable.js
@@ -1,0 +1,13 @@
+/**
+ * Check if given `obj` is an Observable or not.
+ *
+ * @param any obj
+ * @return boolean
+ */
+export default function isObservable(obj) {
+  if (obj && typeof obj.subscribe === 'function') {
+    return true;
+  }
+
+  return false;
+}

--- a/test/utils/isObservable.spec.js
+++ b/test/utils/isObservable.spec.js
@@ -1,0 +1,21 @@
+/* global describe, it */
+import { expect } from 'chai';
+import { Observable } from 'rxjs';
+
+import isObservable from '../../src/utils/isObservable';
+
+describe('utils › isObservable', function () {
+  it('returns true when an Observable is given', function () {
+    const observable = Observable.of('foo', 'bar');
+
+    expect(isObservable(observable)).to.equal(true);
+  });
+
+  it('returns false when something other than an Observable is given', function () {
+    expect(isObservable(null)).to.equal(false);
+    expect(isObservable('hello world')).to.equal(false);
+    expect(isObservable(123)).to.equal(false);
+    expect(isObservable(() => {})).to.equal(false);
+    expect(isObservable(true)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Background

* It is difficult for Widgets to communicate with each other
* A Pub Sub model can help solve the problem
* But our `mapToProps` handles re-renders based on state only

Attempted solution:

* If `mapToProps` can trigger re-renders based on Observables, it would help

## What's done

* A new `observe` key has been introduced in `mapToProps`. And it is expected to return an Observable.
* `rxjs` has been upgraded to v5.0.0-rc.1

## Usage example

```js
// ./components/Root.js
import { Observable } from 'rxjs';
import { createComponent, mapToProps } from 'frint';

const RootComponent = createComponent({
  render() {
    return (
      <div>
        <div>{this.props.appId}</div>
        <div>{this.props.total}</div>
      </div>
    );
  }
});

export default mapToProps({
  observe: (app) => {
    // you have access to `app` instance

    return Observable
      // iterate over these values in a sequence
      .of(1, 2)

      // now convert it to an object, which will be available as props
      .scan(
        // this function would be called twice,
        // first with `1`, and then `2` as number
        (props, number) => {
          props.total = props.total + number;

          return props;
        },

        // the initial object to start the `scan` with
        {
          appId: app.getOption('appId'),
          total: 0
        }
      );
  }
})(RootComponent);
```

The example is a very simple one, but given the `observe` function is passed with the `app` instance, you can get observables from other Services/Factories, and combine them into one, and then produce the final `props` object to be made available in the Component.

And every time the observable emits a new value, it would trigger a re-render in your Component.

## Further reading

We already use Observables in `Region`. 

You can read further about it here: http://reactivex.io/rxjs/