### PR TITLE
New organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 #### Pull Requests
 * `frint-react`
-  * [#356](https://github.com/Travix-International/frint/pull/356) frint-react: className prop in Region component. ([@ascariandrea](https://github.com/ascariandrea))
+  * [#356](https://github.com/frintjs/frint/pull/356) frint-react: className prop in Region component. ([@ascariandrea](https://github.com/ascariandrea))
 * Other
-  * [#353](https://github.com/Travix-International/frint/pull/353) Extracted site out of monorepo. ([@fahad19](https://github.com/fahad19))
+  * [#353](https://github.com/frintjs/frint/pull/353) Extracted site out of monorepo. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Andrea Ascari ([ascariandrea](https://github.com/ascariandrea))
@@ -16,10 +16,10 @@
 
 #### Pull Requests
 * Other
-  * [#351](https://github.com/Travix-International/frint/pull/351) Migration guide for v4. ([@fahad19](https://github.com/fahad19))
-  * [#344](https://github.com/Travix-International/frint/pull/344) Update React in examples. ([@ascariandrea](https://github.com/ascariandrea))
+  * [#351](https://github.com/frintjs/frint/pull/351) Migration guide for v4. ([@fahad19](https://github.com/fahad19))
+  * [#344](https://github.com/frintjs/frint/pull/344) Update React in examples. ([@ascariandrea](https://github.com/ascariandrea))
 * `frint-cli`, `frint-component-handlers`, `frint-component-utils`, `frint-config`, `frint-data`, `frint-model`, `frint-react-server`, `frint-react`, `frint-router`, `frint-store`, `frint`
-  * [#350](https://github.com/Travix-International/frint/pull/350) Upgrade to RxJS v5.5. ([@fahad19](https://github.com/fahad19))
+  * [#350](https://github.com/frintjs/frint/pull/350) Upgrade to RxJS v5.5. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Andrea Ascari ([ascariandrea](https://github.com/ascariandrea))
@@ -29,7 +29,7 @@
 
 #### Pull Requests
 * `frint-config`
-  * [#347](https://github.com/Travix-International/frint/pull/347) frint-config: casing for exported keys. ([@fahad19](https://github.com/fahad19))
+  * [#347](https://github.com/frintjs/frint/pull/347) frint-config: casing for exported keys. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -38,11 +38,11 @@
 
 #### Pull Requests
 * `frint-config`
-  * [#346](https://github.com/Travix-International/frint/pull/346) frint-config: exports. ([@ascariandrea](https://github.com/ascariandrea))
+  * [#346](https://github.com/frintjs/frint/pull/346) frint-config: exports. ([@ascariandrea](https://github.com/ascariandrea))
 * `frint-react`, `frint-router-react`
-  * [#343](https://github.com/Travix-International/frint/pull/343) Fixed frint-router-react tests for React 16 compatibility. ([@ascariandrea](https://github.com/ascariandrea))
+  * [#343](https://github.com/frintjs/frint/pull/343) Fixed frint-router-react tests for React 16 compatibility. ([@ascariandrea](https://github.com/ascariandrea))
 * Other
-  * [#342](https://github.com/Travix-International/frint/pull/342) Add `frint-react-native`. ([@fahad19](https://github.com/fahad19))
+  * [#342](https://github.com/frintjs/frint/pull/342) Add `frint-react-native`. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Andrea Ascari ([ascariandrea](https://github.com/ascariandrea))
@@ -52,7 +52,7 @@
 
 #### Pull Requests
 * `frint-react`
-  * [#341](https://github.com/Travix-International/frint/pull/341) frint-react: load only required modules for `render`. ([@fahad19](https://github.com/fahad19))
+  * [#341](https://github.com/frintjs/frint/pull/341) frint-react: load only required modules for `render`. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -61,9 +61,9 @@
 
 #### Pull Requests
 * `frint-react`
-  * [#339](https://github.com/Travix-International/frint/pull/339) frint-react: `observe` HoC can return props synchronously. ([@fahad19](https://github.com/fahad19))
+  * [#339](https://github.com/frintjs/frint/pull/339) frint-react: `observe` HoC can return props synchronously. ([@fahad19](https://github.com/fahad19))
 * `frint-store`
-  * [#324](https://github.com/Travix-International/frint/pull/324) Update eslint-config-travix to latest. ([@discosultan](https://github.com/discosultan))
+  * [#324](https://github.com/frintjs/frint/pull/324) Update eslint-config-travix to latest. ([@discosultan](https://github.com/discosultan))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -73,7 +73,7 @@
 
 #### Pull Requests
 * `frint-compat`, `frint-component-handlers`, `frint-component-utils`, `frint-config`, `frint-data`, `frint-model`, `frint-react`, `frint-router-component-handlers`, `frint-router-react`, `frint-router`, `frint-store`, `frint`
-  * [#332](https://github.com/Travix-International/frint/pull/332) Webpack: fix for dists. ([@fahad19](https://github.com/fahad19))
+  * [#332](https://github.com/frintjs/frint/pull/332) Webpack: fix for dists. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -82,10 +82,10 @@
 
 #### Pull Requests
 * `frint-router-component-handlers`, `frint-router-react`
-  * [#327](https://github.com/Travix-International/frint/pull/327) frint-router-component-handlers. ([@viacheslaff](https://github.com/viacheslaff))
+  * [#327](https://github.com/frintjs/frint/pull/327) frint-router-component-handlers. ([@viacheslaff](https://github.com/viacheslaff))
 * Other
-  * [#329](https://github.com/Travix-International/frint/pull/329) Update .gitignore to ignore all JetBrains IDEs files under .idea folder. ([@viacheslaff](https://github.com/viacheslaff))
-  * [#328](https://github.com/Travix-International/frint/pull/328) REPL: use Codesandbox.. ([@fahad19](https://github.com/fahad19))
+  * [#329](https://github.com/frintjs/frint/pull/329) Update .gitignore to ignore all JetBrains IDEs files under .idea folder. ([@viacheslaff](https://github.com/viacheslaff))
+  * [#328](https://github.com/frintjs/frint/pull/328) REPL: use Codesandbox.. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -95,9 +95,9 @@
 
 #### Pull Requests
 * `frint-cli`
-  * [#321](https://github.com/Travix-International/frint/pull/321) frint-cli: fix. ([@fahad19](https://github.com/fahad19))
+  * [#321](https://github.com/frintjs/frint/pull/321) frint-cli: fix. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#320](https://github.com/Travix-International/frint/pull/320) Examples: Upgraded to FrintJS v3. ([@fahad19](https://github.com/fahad19))
+  * [#320](https://github.com/frintjs/frint/pull/320) Examples: Upgraded to FrintJS v3. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -106,13 +106,13 @@
 
 #### Pull Requests
 * Other
-  * [#312](https://github.com/Travix-International/frint/pull/312) Docs: Migration guide to v3. ([@fahad19](https://github.com/fahad19))
+  * [#312](https://github.com/frintjs/frint/pull/312) Docs: Migration guide to v3. ([@fahad19](https://github.com/fahad19))
 * `frint-cli`, `frint-compat`, `frint-component-handlers`, `frint-component-utils`, `frint-config`, `frint-data`, `frint-model`, `frint-react-server`, `frint-react`, `frint-router-react`, `frint-router`, `frint-store`, `frint-test-utils`, `frint`
-  * [#316](https://github.com/Travix-International/frint/pull/316) Import RxJS and Lodash modules individually. ([@fahad19](https://github.com/fahad19))
+  * [#316](https://github.com/frintjs/frint/pull/316) Import RxJS and Lodash modules individually. ([@fahad19](https://github.com/fahad19))
 * `frint`
-  * [#309](https://github.com/Travix-International/frint/pull/309) frint: Drop previously deprecated methods.. ([@fahad19](https://github.com/fahad19))
+  * [#309](https://github.com/frintjs/frint/pull/309) frint: Drop previously deprecated methods.. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`
-  * [#267](https://github.com/Travix-International/frint/pull/267) frint-compat: empty the package.. ([@fahad19](https://github.com/fahad19))
+  * [#267](https://github.com/frintjs/frint/pull/267) frint-compat: empty the package.. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -121,7 +121,7 @@
 
 #### Pull Requests
 * `frint-model`, `frint-store`
-  * [#313](https://github.com/Travix-International/frint/pull/313) Show  deprecated warnings when creating Store and Model classes. ([@fahad19](https://github.com/fahad19))
+  * [#313](https://github.com/frintjs/frint/pull/313) Show  deprecated warnings when creating Store and Model classes. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -130,9 +130,9 @@
 
 #### Pull Requests
 * `frint-store`
-  * [#310](https://github.com/Travix-International/frint/pull/310) frint-store: Deprecate `thunkArgument`, and introduce `deps`. ([@fahad19](https://github.com/fahad19))
+  * [#310](https://github.com/frintjs/frint/pull/310) frint-store: Deprecate `thunkArgument`, and introduce `deps`. ([@fahad19](https://github.com/fahad19))
 * `frint-model`
-  * [#308](https://github.com/Travix-International/frint/pull/308) frint-model: Deprecated. ([@fahad19](https://github.com/fahad19))
+  * [#308](https://github.com/frintjs/frint/pull/308) frint-model: Deprecated. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -141,9 +141,9 @@
 
 #### Pull Requests
 * `frint-data`
-  * [#305](https://github.com/Travix-International/frint/pull/305) frint-data: Reactive data modelling. ([@fahad19](https://github.com/fahad19))
+  * [#305](https://github.com/frintjs/frint/pull/305) frint-data: Reactive data modelling. ([@fahad19](https://github.com/fahad19))
 * `frint-cli`, `frint-compat`, `frint-component-handlers`, `frint-component-utils`, `frint-model`, `frint-react-server`, `frint-react`, `frint-router-react`, `frint-router`, `frint-store`, `frint-test-utils`, `frint`
-  * [#304](https://github.com/Travix-International/frint/pull/304) Enable execution of npm scripts within subpackage folder. ([@discosultan](https://github.com/discosultan))
+  * [#304](https://github.com/frintjs/frint/pull/304) Enable execution of npm scripts within subpackage folder. ([@discosultan](https://github.com/discosultan))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -153,7 +153,7 @@
 
 #### Pull Requests
 * `frint-router-react`
-  * [#303](https://github.com/Travix-International/frint/pull/303) frint-router-react: inline rendering via Route component. ([@fahad19](https://github.com/fahad19))
+  * [#303](https://github.com/frintjs/frint/pull/303) frint-router-react: inline rendering via Route component. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -162,7 +162,7 @@
 
 #### Pull Requests
 * `frint-react`
-  * [#295](https://github.com/Travix-International/frint/pull/295) frint-react: Allow observing parent component's props. ([@fahad19](https://github.com/fahad19))
+  * [#295](https://github.com/frintjs/frint/pull/295) frint-react: Allow observing parent component's props. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -171,12 +171,12 @@
 
 #### Pull Requests
 * `frint-cli`
-  * [#283](https://github.com/Travix-International/frint/pull/283) frint-cli: fix init command on Windows platform. ([@discosultan](https://github.com/discosultan))
+  * [#283](https://github.com/frintjs/frint/pull/283) frint-cli: fix init command on Windows platform. ([@discosultan](https://github.com/discosultan))
 * Other
-  * [#293](https://github.com/Travix-International/frint/pull/293) Ignore package-lock.json. ([@discosultan](https://github.com/discosultan))
-  * [#286](https://github.com/Travix-International/frint/pull/286) Remove end of line setting from .editorconfig. ([@discosultan](https://github.com/discosultan))
-  * [#288](https://github.com/Travix-International/frint/pull/288) Fix typo in Hello World guide. ([@discosultan](https://github.com/discosultan))
-  * [#284](https://github.com/Travix-International/frint/pull/284) Link to `frint-vue`.. ([@fahad19](https://github.com/fahad19))
+  * [#293](https://github.com/frintjs/frint/pull/293) Ignore package-lock.json. ([@discosultan](https://github.com/discosultan))
+  * [#286](https://github.com/frintjs/frint/pull/286) Remove end of line setting from .editorconfig. ([@discosultan](https://github.com/discosultan))
+  * [#288](https://github.com/frintjs/frint/pull/288) Fix typo in Hello World guide. ([@discosultan](https://github.com/discosultan))
+  * [#284](https://github.com/frintjs/frint/pull/284) Link to `frint-vue`.. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -186,9 +186,9 @@
 
 #### Pull Requests
 * `frint-component-handlers`, `frint-component-utils`, `frint-react`
-  * [#277](https://github.com/Travix-International/frint/pull/277) Handlers for abstracting reactive components. ([@fahad19](https://github.com/fahad19))
+  * [#277](https://github.com/frintjs/frint/pull/277) Handlers for abstracting reactive components. ([@fahad19](https://github.com/fahad19))
 * `frint-cli`, `frint-compat`, `frint-model`, `frint-react-server`, `frint-react`, `frint-router-react`, `frint-router`, `frint-store`, `frint-test-utils`, `frint`
-  * [#281](https://github.com/Travix-International/frint/pull/281) Fix script errors on Windows platform. ([@discosultan](https://github.com/discosultan))
+  * [#281](https://github.com/frintjs/frint/pull/281) Fix script errors on Windows platform. ([@discosultan](https://github.com/discosultan))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -198,11 +198,11 @@
 
 #### Pull Requests
 * `frint-react`
-  * [#280](https://github.com/Travix-International/frint/pull/280) frint-react: Declare app in context of Region. ([@reaktivo](https://github.com/reaktivo))
-  * [#278](https://github.com/Travix-International/frint/pull/278) Make `isObservable` more generic. ([@DzmitryKukharuk](https://github.com/DzmitryKukharuk))
+  * [#280](https://github.com/frintjs/frint/pull/280) frint-react: Declare app in context of Region. ([@reaktivo](https://github.com/reaktivo))
+  * [#278](https://github.com/frintjs/frint/pull/278) Make `isObservable` more generic. ([@DzmitryKukharuk](https://github.com/DzmitryKukharuk))
 * Other
-  * [#276](https://github.com/Travix-International/frint/pull/276) Remove redundant square brackets from Code of Conduct. ([@gtzio](https://github.com/gtzio))
-  * [#275](https://github.com/Travix-International/frint/pull/275) Code of Conduct. ([@gtzio](https://github.com/gtzio))
+  * [#276](https://github.com/frintjs/frint/pull/276) Remove redundant square brackets from Code of Conduct. ([@gtzio](https://github.com/gtzio))
+  * [#275](https://github.com/frintjs/frint/pull/275) Code of Conduct. ([@gtzio](https://github.com/gtzio))
 
 #### Committers: 3
 - Georgia Tziola ([gtzio](https://github.com/gtzio))
@@ -213,7 +213,7 @@
 
 #### Pull Requests
 * `frint-store`
-  * [#271](https://github.com/Travix-International/frint/pull/271) frint-store: Epics ([@fahad19](https://github.com/fahad19), [@nunorfpt](https://github.com/nunorfpt))
+  * [#271](https://github.com/frintjs/frint/pull/271) frint-store: Epics ([@fahad19](https://github.com/fahad19), [@nunorfpt](https://github.com/nunorfpt))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -223,15 +223,15 @@
 
 #### Pull Requests
 * Other
-  * [#263](https://github.com/Travix-International/frint/pull/263) Site: fix REPL by loading `prop-types`.. ([@fahad19](https://github.com/fahad19))
-  * [#255](https://github.com/Travix-International/frint/pull/255) Homepage: header updated. ([@fahad19](https://github.com/fahad19))
-  * [#254](https://github.com/Travix-International/frint/pull/254) Migration to v1.x docs: Add information about combineReducers. ([@viacheslaff](https://github.com/viacheslaff))
+  * [#263](https://github.com/frintjs/frint/pull/263) Site: fix REPL by loading `prop-types`.. ([@fahad19](https://github.com/fahad19))
+  * [#255](https://github.com/frintjs/frint/pull/255) Homepage: header updated. ([@fahad19](https://github.com/fahad19))
+  * [#254](https://github.com/frintjs/frint/pull/254) Migration to v1.x docs: Add information about combineReducers. ([@viacheslaff](https://github.com/viacheslaff))
 * `frint-compat`, `frint-model`, `frint-react`, `frint-router-react`
-  * [#261](https://github.com/Travix-International/frint/pull/261) Apply Webpack’s `externals` more accurately to reduce dist sizes.. ([@fahad19](https://github.com/fahad19))
+  * [#261](https://github.com/frintjs/frint/pull/261) Apply Webpack’s `externals` more accurately to reduce dist sizes.. ([@fahad19](https://github.com/fahad19))
 * `frint-model`
-  * [#258](https://github.com/Travix-International/frint/pull/258) Extend the prototype of Model at definition time. ([@reaktivo](https://github.com/reaktivo))
+  * [#258](https://github.com/frintjs/frint/pull/258) Extend the prototype of Model at definition time. ([@reaktivo](https://github.com/reaktivo))
 * `frint-store`
-  * [#251](https://github.com/Travix-International/frint/pull/251) frint-store: Fix wrong combineReducers require in docs. ([@viacheslaff](https://github.com/viacheslaff))
+  * [#251](https://github.com/frintjs/frint/pull/251) frint-store: Fix wrong combineReducers require in docs. ([@viacheslaff](https://github.com/viacheslaff))
 
 #### Committers: 3
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -243,7 +243,7 @@
 #### Pull Requests
 
 * `frint-router`, `frint-router-react`, `frint-react`
-  * [#244](https://github.com/Travix-International/frint/pull/244) Router. ([@fahad19](https://github.com/fahad19), [@mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn), [@viacheslaff](https://github.com/viacheslaff))
+  * [#244](https://github.com/frintjs/frint/pull/244) Router. ([@fahad19](https://github.com/fahad19), [@mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn), [@viacheslaff](https://github.com/viacheslaff))
 
 #### Committers: 3
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -254,17 +254,17 @@
 
 #### Pull Requests
 * Other
-  * [#231](https://github.com/Travix-International/frint/pull/231) Update lerna-changelog to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
-  * [#206](https://github.com/Travix-International/frint/pull/206) Feature #193, allow loading root and child apps asynchronously. ([@reaktivo](https://github.com/reaktivo))
-  * [#229](https://github.com/Travix-International/frint/pull/229) Fix for migration guide typos. ([@fahad19](https://github.com/fahad19))
-  * [#227](https://github.com/Travix-International/frint/pull/227) Upgrade all examples  to FrintJS v2.x. ([@fahad19](https://github.com/fahad19))
-  * [#226](https://github.com/Travix-International/frint/pull/226) Migration guide for v2.x. ([@fahad19](https://github.com/fahad19))
+  * [#231](https://github.com/frintjs/frint/pull/231) Update lerna-changelog to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
+  * [#206](https://github.com/frintjs/frint/pull/206) Feature #193, allow loading root and child apps asynchronously. ([@reaktivo](https://github.com/reaktivo))
+  * [#229](https://github.com/frintjs/frint/pull/229) Fix for migration guide typos. ([@fahad19](https://github.com/fahad19))
+  * [#227](https://github.com/frintjs/frint/pull/227) Upgrade all examples  to FrintJS v2.x. ([@fahad19](https://github.com/fahad19))
+  * [#226](https://github.com/frintjs/frint/pull/226) Migration guide for v2.x. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`, `frint-react-server`, `frint-react`, `frint`
-  * [#236](https://github.com/Travix-International/frint/pull/236) frint: new `app.getName` method. ([@gtzio](https://github.com/gtzio))
+  * [#236](https://github.com/frintjs/frint/pull/236) frint: new `app.getName` method. ([@gtzio](https://github.com/gtzio))
 * `frint-compat`, `frint`
-  * [#238](https://github.com/Travix-International/frint/pull/238) Fixes lint issues detected with the newest version of eslint-config-travix. ([@mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+  * [#238](https://github.com/frintjs/frint/pull/238) Fixes lint issues detected with the newest version of eslint-config-travix. ([@mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 * `frint-compat`
-  * [#221](https://github.com/Travix-International/frint/pull/221) Update chai to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
+  * [#221](https://github.com/frintjs/frint/pull/221) Update chai to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 #### Committers: 4
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -280,7 +280,7 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-compat`, `frint-react-server`, `frint-react`
-  * [#213](https://github.com/Travix-International/frint/pull/213) Upgrade all packages to React v15+. ([@fahad19](https://github.com/fahad19))
+  * [#213](https://github.com/frintjs/frint/pull/213) Upgrade all packages to React v15+. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -289,16 +289,16 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-store`
-  * [#225](https://github.com/Travix-International/frint/pull/225) Fix for initializing Stores with combined reducers. ([@fahad19](https://github.com/fahad19))
+  * [#225](https://github.com/frintjs/frint/pull/225) Fix for initializing Stores with combined reducers. ([@fahad19](https://github.com/fahad19))
 * `frint-react`
-  * [#224](https://github.com/Travix-International/frint/pull/224) Minor fix for docs in frint-react. ([@yurist38](https://github.com/yurist38))
+  * [#224](https://github.com/frintjs/frint/pull/224) Minor fix for docs in frint-react. ([@yurist38](https://github.com/yurist38))
 * `frint-preset-travix`
-  * [#223](https://github.com/Travix-International/frint/pull/223) Removed `frint-preset-travix` from monorepo. ([@fahad19](https://github.com/fahad19))
+  * [#223](https://github.com/frintjs/frint/pull/223) Removed `frint-preset-travix` from monorepo. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#214](https://github.com/Travix-International/frint/pull/214) Update lerna-changelog to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
-  * [#218](https://github.com/Travix-International/frint/pull/218) Update nyc to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
-  * [#222](https://github.com/Travix-International/frint/pull/222) Fixes for `alex`. ([@fahad19](https://github.com/fahad19))
-  * [#219](https://github.com/Travix-International/frint/pull/219) Quick start with `frint-cli`, and getting rid of Makefile in examples. ([@fahad19](https://github.com/fahad19))
+  * [#214](https://github.com/frintjs/frint/pull/214) Update lerna-changelog to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
+  * [#218](https://github.com/frintjs/frint/pull/218) Update nyc to the latest version 🚀. ([@greenkeeper[bot]](https://github.com/apps/greenkeeper))
+  * [#222](https://github.com/frintjs/frint/pull/222) Fixes for `alex`. ([@fahad19](https://github.com/fahad19))
+  * [#219](https://github.com/frintjs/frint/pull/219) Quick start with `frint-cli`, and getting rid of Makefile in examples. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -308,7 +308,7 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-cli`
-  * [#212](https://github.com/Travix-International/frint/pull/212) frint-cli: fix for `init` by removing extra space from command. ([@fahad19](https://github.com/fahad19))
+  * [#212](https://github.com/frintjs/frint/pull/212) frint-cli: fix for `init` by removing extra space from command. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -317,16 +317,16 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-cli`, `frint-model`
-  * [#211](https://github.com/Travix-International/frint/pull/211) Show `frint-cli` docs in site. ([@fahad19](https://github.com/fahad19))
+  * [#211](https://github.com/frintjs/frint/pull/211) Show `frint-cli` docs in site. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`, `frint-react-server`, `frint-react`
-  * [#210](https://github.com/Travix-International/frint/pull/210) Root dependencies cleaned up. ([@fahad19](https://github.com/fahad19))
+  * [#210](https://github.com/frintjs/frint/pull/210) Root dependencies cleaned up. ([@fahad19](https://github.com/fahad19))
 * `frint-cli`
-  * [#209](https://github.com/Travix-International/frint/pull/209) Frint CLI. ([@fahad19](https://github.com/fahad19))
+  * [#209](https://github.com/frintjs/frint/pull/209) Frint CLI. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#200](https://github.com/Travix-International/frint/pull/200) Examples: use Html webpack plugin. ([@asci](https://github.com/asci))
-  * [#190](https://github.com/Travix-International/frint/pull/190) Examples: `multiple-apps` upgraded to use Frint v1.x. ([@fahad19](https://github.com/fahad19))
+  * [#200](https://github.com/frintjs/frint/pull/200) Examples: use Html webpack plugin. ([@asci](https://github.com/asci))
+  * [#190](https://github.com/frintjs/frint/pull/190) Examples: `multiple-apps` upgraded to use Frint v1.x. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`, `frint-react`
-  * [#199](https://github.com/Travix-International/frint/pull/199) ESLint fixes in tests. ([@fahad19](https://github.com/fahad19))
+  * [#199](https://github.com/frintjs/frint/pull/199) ESLint fixes in tests. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Artem Riasnianskyi ([asci](https://github.com/asci))
@@ -336,12 +336,12 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-model`, `frint-react`, `frint-store`, `frint`
-  * [#189](https://github.com/Travix-International/frint/pull/189) Typescript example. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#189](https://github.com/frintjs/frint/pull/189) Typescript example. ([@jackTheRipper](https://github.com/jackTheRipper))
 * Other
-  * [#177](https://github.com/Travix-International/frint/pull/177) Fix examples. ([@jackTheRipper](https://github.com/jackTheRipper))
-  * [#188](https://github.com/Travix-International/frint/pull/188) Docs: migration guide for components. ([@fahad19](https://github.com/fahad19))
-  * [#187](https://github.com/Travix-International/frint/pull/187) Update copyright year in LICENSE file. ([@gtzio](https://github.com/gtzio))
-  * [#176](https://github.com/Travix-International/frint/pull/176) Make one package.json for Kitchensink example. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#177](https://github.com/frintjs/frint/pull/177) Fix examples. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#188](https://github.com/frintjs/frint/pull/188) Docs: migration guide for components. ([@fahad19](https://github.com/fahad19))
+  * [#187](https://github.com/frintjs/frint/pull/187) Update copyright year in LICENSE file. ([@gtzio](https://github.com/gtzio))
+  * [#176](https://github.com/frintjs/frint/pull/176) Make one package.json for Kitchensink example. ([@jackTheRipper](https://github.com/jackTheRipper))
 
 #### Committers: 3
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -352,11 +352,11 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-model`, `frint-react-server`, `frint-react`, `frint-store`, `frint-test-utils`, `frint`
-  * [#171](https://github.com/Travix-International/frint/pull/171) TR-13266 Typings for frint. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#171](https://github.com/frintjs/frint/pull/171) TR-13266 Typings for frint. ([@jackTheRipper](https://github.com/jackTheRipper))
 * Other
-  * [#168](https://github.com/Travix-International/frint/pull/168) Changed selection color (#146). ([@AlexDudar](https://github.com/AlexDudar))
+  * [#168](https://github.com/frintjs/frint/pull/168) Changed selection color (#146). ([@AlexDudar](https://github.com/AlexDudar))
 * `frint-model`
-  * [#166](https://github.com/Travix-International/frint/pull/166) Make models streamable. ([@fahad19](https://github.com/fahad19))
+  * [#166](https://github.com/frintjs/frint/pull/166) Make models streamable. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 4
 - Alexandr Dudar ([AlexDudar](https://github.com/AlexDudar))
@@ -367,7 +367,7 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-preset-travix`
-  * [#165](https://github.com/Travix-International/frint/pull/165) Pin package versions in Travix preset. ([@fahad19](https://github.com/fahad19))
+  * [#165](https://github.com/frintjs/frint/pull/165) Pin package versions in Travix preset. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 1
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -376,9 +376,9 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-preset-travix`
-  * [#164](https://github.com/Travix-International/frint/pull/164) Preset for Travix. ([@fahad19](https://github.com/fahad19))
+  * [#164](https://github.com/frintjs/frint/pull/164) Preset for Travix. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#161](https://github.com/Travix-International/frint/pull/161) Unit tests for example. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#161](https://github.com/frintjs/frint/pull/161) Unit tests for example. ([@jackTheRipper](https://github.com/jackTheRipper))
 
 #### Committers: 2
 - Fahad Ibnay Heylaal ([fahad19](https://github.com/fahad19))
@@ -388,9 +388,9 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-compat`, `frint-react-server`, `frint-react`, `frint`
-  * [#160](https://github.com/Travix-International/frint/pull/160) Deprecate *Widget* methods. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#160](https://github.com/frintjs/frint/pull/160) Deprecate *Widget* methods. ([@alexmiranda](https://github.com/alexmiranda))
 * Other
-  * [#155](https://github.com/Travix-International/frint/pull/155) Add search functionality with Algolia. ([@markvincze](https://github.com/markvincze))
+  * [#155](https://github.com/frintjs/frint/pull/155) Add search functionality with Algolia. ([@markvincze](https://github.com/markvincze))
 
 #### Committers: 2
 - Alex Miranda ([alexmiranda](https://github.com/alexmiranda))
@@ -400,11 +400,11 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-compat`
-  * [#154](https://github.com/Travix-International/frint/pull/154) frint-compat: fixes for readableApps. ([@fahad19](https://github.com/fahad19))
+  * [#154](https://github.com/frintjs/frint/pull/154) frint-compat: fixes for readableApps. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`, `frint`
-  * [#152](https://github.com/Travix-International/frint/pull/152) App hierarchy. ([@fahad19](https://github.com/fahad19))
+  * [#152](https://github.com/frintjs/frint/pull/152) App hierarchy. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#148](https://github.com/Travix-International/frint/pull/148) Updated styles. ([@AlexDudar](https://github.com/AlexDudar))
+  * [#148](https://github.com/frintjs/frint/pull/148) Updated styles. ([@AlexDudar](https://github.com/AlexDudar))
 
 #### Committers: 2
 - Alexandr Dudar ([AlexDudar](https://github.com/AlexDudar))
@@ -414,14 +414,14 @@ Maintenance release to force all package versions in the monorepo to be same.
 
 #### Pull Requests
 * `frint-compat`
-  * [#147](https://github.com/Travix-International/frint/pull/147) frint-compat: register models before services and factories.. ([@fahad19](https://github.com/fahad19))
+  * [#147](https://github.com/frintjs/frint/pull/147) frint-compat: register models before services and factories.. ([@fahad19](https://github.com/fahad19))
 * Other
-  * [#137](https://github.com/Travix-International/frint/pull/137) Fix typo in guides sidebar. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#137](https://github.com/frintjs/frint/pull/137) Fix typo in guides sidebar. ([@alexmiranda](https://github.com/alexmiranda))
 * `frint-model`, `frint`
-  * [#136](https://github.com/Travix-International/frint/pull/136) Add install section to frint-model docs. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#136](https://github.com/frintjs/frint/pull/136) Add install section to frint-model docs. ([@alexmiranda](https://github.com/alexmiranda))
 * `frint-model`
-  * [#135](https://github.com/Travix-International/frint/pull/135) Fix TOC. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#134](https://github.com/Travix-International/frint/pull/134) Fix for bad merge with frint-model's README, introduced in #101. ([@fahad19](https://github.com/fahad19))
+  * [#135](https://github.com/frintjs/frint/pull/135) Fix TOC. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#134](https://github.com/frintjs/frint/pull/134) Fix for bad merge with frint-model's README, introduced in #101. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 2
 - Alex Miranda ([alexmiranda](https://github.com/alexmiranda))
@@ -432,46 +432,46 @@ Maintenance release to force all package versions in the monorepo to be same.
 #### Pull Requests
 
 * `frint-model`
-  * [#101](https://github.com/Travix-International/frint/pull/101) README for frint-model package. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#101](https://github.com/frintjs/frint/pull/101) README for frint-model package. ([@alexmiranda](https://github.com/alexmiranda))
 * Other
-  * [#133](https://github.com/Travix-International/frint/pull/133) Site: remove dead links.. ([@fahad19](https://github.com/fahad19))
-  * [#126](https://github.com/Travix-International/frint/pull/126) Site: Homepage. ([@fahad19](https://github.com/fahad19))
-  * [#125](https://github.com/Travix-International/frint/pull/125) Guides: Observables. ([@fahad19](https://github.com/fahad19))
-  * [#124](https://github.com/Travix-International/frint/pull/124) Drop Gitbook. ([@fahad19](https://github.com/fahad19))
-  * [#123](https://github.com/Travix-International/frint/pull/123) Site: command for publishing site.. ([@fahad19](https://github.com/fahad19))
-  * [#121](https://github.com/Travix-International/frint/pull/121) Guides: illustrations. ([@fahad19](https://github.com/fahad19))
-  * [#120](https://github.com/Travix-International/frint/pull/120) Site: analytics. ([@fahad19](https://github.com/fahad19))
-  * [#119](https://github.com/Travix-International/frint/pull/119) Guides: Region illustration. ([@fahad19](https://github.com/fahad19))
-  * [#117](https://github.com/Travix-International/frint/pull/117) Migration guide updated to reflect monorepo. ([@fahad19](https://github.com/fahad19))
-  * [#111](https://github.com/Travix-International/frint/pull/111) Site: About page. ([@fahad19](https://github.com/fahad19))
-  * [#113](https://github.com/Travix-International/frint/pull/113) REPL. ([@fahad19](https://github.com/fahad19))
-  * [#112](https://github.com/Travix-International/frint/pull/112) Docs: Guides for State Management and Code Splitting. ([@fahad19](https://github.com/fahad19))
-  * [#110](https://github.com/Travix-International/frint/pull/110) Guides: Concepts of App, Provider, Component, Region. ([@fahad19](https://github.com/fahad19))
-  * [#108](https://github.com/Travix-International/frint/pull/108) Documentation site. ([@fahad19](https://github.com/fahad19))
-  * [#107](https://github.com/Travix-International/frint/pull/107) Allow port number to be changed with make args. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#99](https://github.com/Travix-International/frint/pull/99) Remove requirement for extending `App` from react plugin. ([@fahad19](https://github.com/fahad19))
-  * [#97](https://github.com/Travix-International/frint/pull/97) Remove jsdom-global package.. ([@fahad19](https://github.com/fahad19))
-  * [#96](https://github.com/Travix-International/frint/pull/96) Fix unit tests. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#95](https://github.com/Travix-International/frint/pull/95) Fix import. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#94](https://github.com/Travix-International/frint/pull/94) Organisation of `spec` files. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#93](https://github.com/Travix-International/frint/pull/93) Memory leak. ([@jackTheRipper](https://github.com/jackTheRipper))
-  * [#92](https://github.com/Travix-International/frint/pull/92) Documentation for Model `get` method. ([@alexmiranda](https://github.com/alexmiranda))
-  * [#91](https://github.com/Travix-International/frint/pull/91) Extract lifecycle hooks to react package. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#133](https://github.com/frintjs/frint/pull/133) Site: remove dead links.. ([@fahad19](https://github.com/fahad19))
+  * [#126](https://github.com/frintjs/frint/pull/126) Site: Homepage. ([@fahad19](https://github.com/fahad19))
+  * [#125](https://github.com/frintjs/frint/pull/125) Guides: Observables. ([@fahad19](https://github.com/fahad19))
+  * [#124](https://github.com/frintjs/frint/pull/124) Drop Gitbook. ([@fahad19](https://github.com/fahad19))
+  * [#123](https://github.com/frintjs/frint/pull/123) Site: command for publishing site.. ([@fahad19](https://github.com/fahad19))
+  * [#121](https://github.com/frintjs/frint/pull/121) Guides: illustrations. ([@fahad19](https://github.com/fahad19))
+  * [#120](https://github.com/frintjs/frint/pull/120) Site: analytics. ([@fahad19](https://github.com/fahad19))
+  * [#119](https://github.com/frintjs/frint/pull/119) Guides: Region illustration. ([@fahad19](https://github.com/fahad19))
+  * [#117](https://github.com/frintjs/frint/pull/117) Migration guide updated to reflect monorepo. ([@fahad19](https://github.com/fahad19))
+  * [#111](https://github.com/frintjs/frint/pull/111) Site: About page. ([@fahad19](https://github.com/fahad19))
+  * [#113](https://github.com/frintjs/frint/pull/113) REPL. ([@fahad19](https://github.com/fahad19))
+  * [#112](https://github.com/frintjs/frint/pull/112) Docs: Guides for State Management and Code Splitting. ([@fahad19](https://github.com/fahad19))
+  * [#110](https://github.com/frintjs/frint/pull/110) Guides: Concepts of App, Provider, Component, Region. ([@fahad19](https://github.com/fahad19))
+  * [#108](https://github.com/frintjs/frint/pull/108) Documentation site. ([@fahad19](https://github.com/fahad19))
+  * [#107](https://github.com/frintjs/frint/pull/107) Allow port number to be changed with make args. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#99](https://github.com/frintjs/frint/pull/99) Remove requirement for extending `App` from react plugin. ([@fahad19](https://github.com/fahad19))
+  * [#97](https://github.com/frintjs/frint/pull/97) Remove jsdom-global package.. ([@fahad19](https://github.com/fahad19))
+  * [#96](https://github.com/frintjs/frint/pull/96) Fix unit tests. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#95](https://github.com/frintjs/frint/pull/95) Fix import. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#94](https://github.com/frintjs/frint/pull/94) Organisation of `spec` files. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#93](https://github.com/frintjs/frint/pull/93) Memory leak. ([@jackTheRipper](https://github.com/jackTheRipper))
+  * [#92](https://github.com/frintjs/frint/pull/92) Documentation for Model `get` method. ([@alexmiranda](https://github.com/alexmiranda))
+  * [#91](https://github.com/frintjs/frint/pull/91) Extract lifecycle hooks to react package. ([@alexmiranda](https://github.com/alexmiranda))
 * `frint-compat`, `frint-model`, `frint-react-server`, `frint-react`, `frint-store`, `frint-test-utils`, `frint`
-  * [#132](https://github.com/Travix-International/frint/pull/132) Coveralls integration for monorepo. ([@fahad19](https://github.com/fahad19))
-  * [#122](https://github.com/Travix-International/frint/pull/122) Drop plugin concept. ([@fahad19](https://github.com/fahad19))
+  * [#132](https://github.com/frintjs/frint/pull/132) Coveralls integration for monorepo. ([@fahad19](https://github.com/fahad19))
+  * [#122](https://github.com/frintjs/frint/pull/122) Drop plugin concept. ([@fahad19](https://github.com/fahad19))
 * `frint-compat`, `frint-react-server`, `frint-react`, `frint`
-  * [#130](https://github.com/Travix-International/frint/pull/130) Drop aliased functions. ([@fahad19](https://github.com/fahad19))
+  * [#130](https://github.com/frintjs/frint/pull/130) Drop aliased functions. ([@fahad19](https://github.com/fahad19))
 * `frint-react`
-  * [#129](https://github.com/Travix-International/frint/pull/129) Test observed components with enzyme. ([@fahad19](https://github.com/fahad19))
+  * [#129](https://github.com/frintjs/frint/pull/129) Test observed components with enzyme. ([@fahad19](https://github.com/fahad19))
 * `frint-react-server`
-  * [#128](https://github.com/Travix-International/frint/pull/128) Test: Server-side rendering with props coming from Observable. ([@fahad19](https://github.com/fahad19))
+  * [#128](https://github.com/frintjs/frint/pull/128) Test: Server-side rendering with props coming from Observable. ([@fahad19](https://github.com/fahad19))
 * `frint`
-  * [#118](https://github.com/Travix-International/frint/pull/118) Use forked `travix-di`, instead of `diyai`.. ([@fahad19](https://github.com/fahad19))
+  * [#118](https://github.com/frintjs/frint/pull/118) Use forked `travix-di`, instead of `diyai`.. ([@fahad19](https://github.com/fahad19))
 * `frint-react`, `frint`
-  * [#109](https://github.com/Travix-International/frint/pull/109) App lifecycle (destroy). ([@fahad19](https://github.com/fahad19))
+  * [#109](https://github.com/frintjs/frint/pull/109) App lifecycle (destroy). ([@fahad19](https://github.com/fahad19))
 * `MIGRATION.md`, `frint-compat`, `frint-model`, `frint-react-server`, `frint-react`, `frint-store`, `frint-test-utils`, `frint`
-  * [#104](https://github.com/Travix-International/frint/pull/104) Monorepo with Lerna. ([@fahad19](https://github.com/fahad19))
+  * [#104](https://github.com/frintjs/frint/pull/104) Monorepo with Lerna. ([@fahad19](https://github.com/fahad19))
 
 #### Committers: 5
 - Alex Miranda ([alexmiranda](https://github.com/alexmiranda))
@@ -479,249 +479,249 @@ Maintenance release to force all package versions in the monorepo to be same.
 - Jean Baudin ([jackTheRipper](https://github.com/jackTheRipper))
 - Uladzimir Dziomin ([spzm](https://github.com/spzm))
 
-## [v0.14.0](https://github.com/Travix-International/frint/tree/v0.14.0) (2017-01-20)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.13.0...v0.14.0)
+## [v0.14.0](https://github.com/frintjs/frint/tree/v0.14.0) (2017-01-20)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.13.0...v0.14.0)
 
 **Merged pull requests:**
 
-- Adds support to "render" method of "createApp" for arguments [\#80](https://github.com/Travix-International/frint/pull/80) ([paulcodiny](https://github.com/paulcodiny))
+- Adds support to "render" method of "createApp" for arguments [\#80](https://github.com/frintjs/frint/pull/80) ([paulcodiny](https://github.com/paulcodiny))
 
-## [v0.13.0](https://github.com/Travix-International/frint/tree/v0.13.0) (2017-01-11)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.12.0...v0.13.0)
-
-**Merged pull requests:**
-
-- Models: `initialize` lifecycle method. [\#78](https://github.com/Travix-International/frint/pull/78) ([fahad19](https://github.com/fahad19))
-- Undeprecate `Store.getState\(\)`. [\#77](https://github.com/Travix-International/frint/pull/77) ([fahad19](https://github.com/fahad19))
-- Update link to docs [\#75](https://github.com/Travix-International/frint/pull/75) ([alexmiranda](https://github.com/alexmiranda))
-- CNAME for frint.js.org [\#73](https://github.com/Travix-International/frint/pull/73) ([fahad19](https://github.com/fahad19))
-- Store management with `createStore` [\#71](https://github.com/Travix-International/frint/pull/71) ([fahad19](https://github.com/fahad19))
-
-## [v0.12.0](https://github.com/Travix-International/frint/tree/v0.12.0) (2016-12-28)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.11.0...v0.12.0)
+## [v0.13.0](https://github.com/frintjs/frint/tree/v0.13.0) (2017-01-11)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.12.0...v0.13.0)
 
 **Merged pull requests:**
 
-- Logger middleware [\#70](https://github.com/Travix-International/frint/pull/70) ([fahad19](https://github.com/fahad19))
-- Examples: use CDN url for `frint` [\#69](https://github.com/Travix-International/frint/pull/69) ([fahad19](https://github.com/fahad19))
+- Models: `initialize` lifecycle method. [\#78](https://github.com/frintjs/frint/pull/78) ([fahad19](https://github.com/fahad19))
+- Undeprecate `Store.getState\(\)`. [\#77](https://github.com/frintjs/frint/pull/77) ([fahad19](https://github.com/fahad19))
+- Update link to docs [\#75](https://github.com/frintjs/frint/pull/75) ([alexmiranda](https://github.com/alexmiranda))
+- CNAME for frint.js.org [\#73](https://github.com/frintjs/frint/pull/73) ([fahad19](https://github.com/fahad19))
+- Store management with `createStore` [\#71](https://github.com/frintjs/frint/pull/71) ([fahad19](https://github.com/fahad19))
 
-## [v0.11.0](https://github.com/Travix-International/frint/tree/v0.11.0) (2016-12-16)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.10.3...v0.11.0)
-
-**Merged pull requests:**
-
-- Hyperscript for JSX [\#63](https://github.com/Travix-International/frint/pull/63) ([fahad19](https://github.com/fahad19))
-
-## [v0.10.3](https://github.com/Travix-International/frint/tree/v0.10.3) (2016-12-14)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.10.2...v0.10.3)
+## [v0.12.0](https://github.com/frintjs/frint/tree/v0.12.0) (2016-12-28)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.11.0...v0.12.0)
 
 **Merged pull requests:**
 
-- Check if `window` exists in Region [\#62](https://github.com/Travix-International/frint/pull/62) ([fahad19](https://github.com/fahad19))
+- Logger middleware [\#70](https://github.com/frintjs/frint/pull/70) ([fahad19](https://github.com/fahad19))
+- Examples: use CDN url for `frint` [\#69](https://github.com/frintjs/frint/pull/69) ([fahad19](https://github.com/fahad19))
 
-## [v0.10.2](https://github.com/Travix-International/frint/tree/v0.10.2) (2016-12-14)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.10.1...v0.10.2)
-
-**Merged pull requests:**
-
-- Check if `window` exists before setting Root app [\#61](https://github.com/Travix-International/frint/pull/61) ([fahad19](https://github.com/fahad19))
-- Gitbook upgraded to latest version [\#60](https://github.com/Travix-International/frint/pull/60) ([fahad19](https://github.com/fahad19))
-- Generate dist when publishing to npm [\#59](https://github.com/Travix-International/frint/pull/59) ([fahad19](https://github.com/fahad19))
-- Maintainers guide [\#58](https://github.com/Travix-International/frint/pull/58) ([fahad19](https://github.com/fahad19))
-
-## [v0.10.1](https://github.com/Travix-International/frint/tree/v0.10.1) (2016-12-13)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.10.0...v0.10.1)
+## [v0.11.0](https://github.com/frintjs/frint/tree/v0.11.0) (2016-12-16)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.10.3...v0.11.0)
 
 **Merged pull requests:**
 
-- Remove ES6 Model class documentation [\#57](https://github.com/Travix-International/frint/pull/57) ([alexmiranda](https://github.com/alexmiranda))
+- Hyperscript for JSX [\#63](https://github.com/frintjs/frint/pull/63) ([fahad19](https://github.com/fahad19))
 
-## [v0.10.0](https://github.com/Travix-International/frint/tree/v0.10.0) (2016-12-13)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.9.2...v0.10.0)
+## [v0.10.3](https://github.com/frintjs/frint/tree/v0.10.3) (2016-12-14)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.10.2...v0.10.3)
+
+**Merged pull requests:**
+
+- Check if `window` exists in Region [\#62](https://github.com/frintjs/frint/pull/62) ([fahad19](https://github.com/fahad19))
+
+## [v0.10.2](https://github.com/frintjs/frint/tree/v0.10.2) (2016-12-14)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.10.1...v0.10.2)
+
+**Merged pull requests:**
+
+- Check if `window` exists before setting Root app [\#61](https://github.com/frintjs/frint/pull/61) ([fahad19](https://github.com/fahad19))
+- Gitbook upgraded to latest version [\#60](https://github.com/frintjs/frint/pull/60) ([fahad19](https://github.com/fahad19))
+- Generate dist when publishing to npm [\#59](https://github.com/frintjs/frint/pull/59) ([fahad19](https://github.com/fahad19))
+- Maintainers guide [\#58](https://github.com/frintjs/frint/pull/58) ([fahad19](https://github.com/fahad19))
+
+## [v0.10.1](https://github.com/frintjs/frint/tree/v0.10.1) (2016-12-13)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.10.0...v0.10.1)
+
+**Merged pull requests:**
+
+- Remove ES6 Model class documentation [\#57](https://github.com/frintjs/frint/pull/57) ([alexmiranda](https://github.com/alexmiranda))
+
+## [v0.10.0](https://github.com/frintjs/frint/tree/v0.10.0) (2016-12-13)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.9.2...v0.10.0)
 
 **Closed issues:**
 
-- An in-range update of babel-core is breaking the build 🚨 [\#55](https://github.com/Travix-International/frint/issues/55)
+- An in-range update of babel-core is breaking the build 🚨 [\#55](https://github.com/frintjs/frint/issues/55)
 
 **Merged pull requests:**
 
-- Non-blocking Regions for Widgets sharing state [\#56](https://github.com/Travix-International/frint/pull/56) ([fahad19](https://github.com/fahad19))
-- Remove TODO for leak that is already taken care of [\#54](https://github.com/Travix-International/frint/pull/54) ([fahad19](https://github.com/fahad19))
-- Make `name` a required option in App [\#53](https://github.com/Travix-International/frint/pull/53) ([fahad19](https://github.com/fahad19))
-- Remove `appId` as a requirement [\#52](https://github.com/Travix-International/frint/pull/52) ([fahad19](https://github.com/fahad19))
-- Uses alexjs's ability to receive globs in order to parse other extensions [\#51](https://github.com/Travix-International/frint/pull/51) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Non-blocking Regions for Widgets sharing state [\#56](https://github.com/frintjs/frint/pull/56) ([fahad19](https://github.com/fahad19))
+- Remove TODO for leak that is already taken care of [\#54](https://github.com/frintjs/frint/pull/54) ([fahad19](https://github.com/fahad19))
+- Make `name` a required option in App [\#53](https://github.com/frintjs/frint/pull/53) ([fahad19](https://github.com/fahad19))
+- Remove `appId` as a requirement [\#52](https://github.com/frintjs/frint/pull/52) ([fahad19](https://github.com/fahad19))
+- Uses alexjs's ability to receive globs in order to parse other extensions [\#51](https://github.com/frintjs/frint/pull/51) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
-## [v0.9.2](https://github.com/Travix-International/frint/tree/v0.9.2) (2016-11-23)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.9.1...v0.9.2)
-
-**Merged pull requests:**
-
-- Update eslint-plugin-babel to the latest version 🚀 [\#45](https://github.com/Travix-International/frint/pull/45) ([greenkeeper[bot]](https://github.com/integration/greenkeeper))
-
-## [v0.9.1](https://github.com/Travix-International/frint/tree/v0.9.1) (2016-11-23)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.9.0...v0.9.1)
+## [v0.9.2](https://github.com/frintjs/frint/tree/v0.9.2) (2016-11-23)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.9.1...v0.9.2)
 
 **Merged pull requests:**
 
-- Adds greenkeeper ignore and updates .gitignore [\#50](https://github.com/Travix-International/frint/pull/50) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Remove redundant `prepublish` script, already taken care of by `Makefile`. [\#49](https://github.com/Travix-International/frint/pull/49) ([fahad19](https://github.com/fahad19))
-- Middleware for asynchronous actions [\#48](https://github.com/Travix-International/frint/pull/48) ([fahad19](https://github.com/fahad19))
-- Rename middleware test file name to follow convention [\#47](https://github.com/Travix-International/frint/pull/47) ([fahad19](https://github.com/fahad19))
+- Update eslint-plugin-babel to the latest version 🚀 [\#45](https://github.com/frintjs/frint/pull/45) ([greenkeeper[bot]](https://github.com/integration/greenkeeper))
 
-## [v0.9.0](https://github.com/Travix-International/frint/tree/v0.9.0) (2016-11-18)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.8.1...v0.9.0)
+## [v0.9.1](https://github.com/frintjs/frint/tree/v0.9.1) (2016-11-23)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.9.0...v0.9.1)
 
 **Merged pull requests:**
 
-- Server-side rendering [\#46](https://github.com/Travix-International/frint/pull/46) ([fahad19](https://github.com/fahad19))
+- Adds greenkeeper ignore and updates .gitignore [\#50](https://github.com/frintjs/frint/pull/50) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Remove redundant `prepublish` script, already taken care of by `Makefile`. [\#49](https://github.com/frintjs/frint/pull/49) ([fahad19](https://github.com/fahad19))
+- Middleware for asynchronous actions [\#48](https://github.com/frintjs/frint/pull/48) ([fahad19](https://github.com/fahad19))
+- Rename middleware test file name to follow convention [\#47](https://github.com/frintjs/frint/pull/47) ([fahad19](https://github.com/fahad19))
 
-## [v0.8.1](https://github.com/Travix-International/frint/tree/v0.8.1) (2016-11-15)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.8.0...v0.8.1)
-
-**Merged pull requests:**
-
-- Fixes issue about reducers not receiving arguments passed to actions. [\#42](https://github.com/Travix-International/frint/pull/42) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-
-## [v0.8.0](https://github.com/Travix-International/frint/tree/v0.8.0) (2016-11-15)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.7.0...v0.8.0)
+## [v0.9.0](https://github.com/frintjs/frint/tree/v0.9.0) (2016-11-18)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.8.1...v0.9.0)
 
 **Merged pull requests:**
 
-- Adds node security project's badge to the README.md [\#41](https://github.com/Travix-International/frint/pull/41) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Update dependencies to enable Greenkeeper 🌴 [\#38](https://github.com/Travix-International/frint/pull/38) ([greenkeeper[bot]](https://github.com/integration/greenkeeper))
+- Server-side rendering [\#46](https://github.com/frintjs/frint/pull/46) ([fahad19](https://github.com/fahad19))
 
-## [v0.7.0](https://github.com/Travix-International/frint/tree/v0.7.0) (2016-11-08)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.6.0...v0.7.0)
-
-**Merged pull requests:**
-
-- State as an Observable [\#40](https://github.com/Travix-International/frint/pull/40) ([fahad19](https://github.com/fahad19))
-
-## [v0.6.0](https://github.com/Travix-International/frint/tree/v0.6.0) (2016-11-01)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.5.0...v0.6.0)
+## [v0.8.1](https://github.com/frintjs/frint/tree/v0.8.1) (2016-11-15)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.8.0...v0.8.1)
 
 **Merged pull requests:**
 
-- mapToProps: support new `observe` key for Observables [\#39](https://github.com/Travix-International/frint/pull/39) ([fahad19](https://github.com/fahad19))
+- Fixes issue about reducers not receiving arguments passed to actions. [\#42](https://github.com/frintjs/frint/pull/42) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
-## [v0.5.0](https://github.com/Travix-International/frint/tree/v0.5.0) (2016-10-31)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.7...v0.5.0)
-
-**Merged pull requests:**
-
-- App: new `setRegions` method [\#37](https://github.com/Travix-International/frint/pull/37) ([fahad19](https://github.com/fahad19))
-- Tests: for `mapToProps`, `createApp`, and middleware [\#36](https://github.com/Travix-International/frint/pull/36) ([fahad19](https://github.com/fahad19))
-
-## [v0.4.7](https://github.com/Travix-International/frint/tree/v0.4.7) (2016-10-27)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.6...v0.4.7)
+## [v0.8.0](https://github.com/frintjs/frint/tree/v0.8.0) (2016-11-15)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.7.0...v0.8.0)
 
 **Merged pull requests:**
 
-- Trigger `initialize\(\)` method in Service and Factory with constructor options [\#35](https://github.com/Travix-International/frint/pull/35) ([fahad19](https://github.com/fahad19))
-- Changelogs [\#34](https://github.com/Travix-International/frint/pull/34) ([fahad19](https://github.com/fahad19))
+- Adds node security project's badge to the README.md [\#41](https://github.com/frintjs/frint/pull/41) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Update dependencies to enable Greenkeeper 🌴 [\#38](https://github.com/frintjs/frint/pull/38) ([greenkeeper[bot]](https://github.com/integration/greenkeeper))
 
-## [v0.4.6](https://github.com/Travix-International/frint/tree/v0.4.6) (2016-10-20)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.5...v0.4.6)
-
-## [v0.4.5](https://github.com/Travix-International/frint/tree/v0.4.5) (2016-10-20)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.4...v0.4.5)
+## [v0.7.0](https://github.com/frintjs/frint/tree/v0.7.0) (2016-11-08)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.6.0...v0.7.0)
 
 **Merged pull requests:**
 
-- Fix: for passing initial shared state across Widgets [\#33](https://github.com/Travix-International/frint/pull/33) ([fahad19](https://github.com/fahad19))
-- Fix mixed ES syntax [\#32](https://github.com/Travix-International/frint/pull/32) ([alexmiranda](https://github.com/alexmiranda))
+- State as an Observable [\#40](https://github.com/frintjs/frint/pull/40) ([fahad19](https://github.com/fahad19))
 
-## [v0.4.4](https://github.com/Travix-International/frint/tree/v0.4.4) (2016-09-01)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.3...v0.4.4)
-
-**Merged pull requests:**
-
-- Fixes Region to differentiate widgets with the same name but different appNames [\#31](https://github.com/Travix-International/frint/pull/31) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
--  FAQ section and improvement on createComponent method [\#30](https://github.com/Travix-International/frint/pull/30) ([heidilaw4](https://github.com/heidilaw4))
-- TR-11332 Add eslint-config-travix to frint [\#29](https://github.com/Travix-International/frint/pull/29) ([markvincze](https://github.com/markvincze))
-- Implement `alex` for linting docs [\#27](https://github.com/Travix-International/frint/pull/27) ([fahad19](https://github.com/fahad19))
-
-## [v0.4.3](https://github.com/Travix-International/frint/tree/v0.4.3) (2016-08-19)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.2...v0.4.3)
+## [v0.6.0](https://github.com/frintjs/frint/tree/v0.6.0) (2016-11-01)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.5.0...v0.6.0)
 
 **Merged pull requests:**
 
-- Make root index.js es5 compatible [\#28](https://github.com/Travix-International/frint/pull/28) ([fahad19](https://github.com/fahad19))
+- mapToProps: support new `observe` key for Observables [\#39](https://github.com/frintjs/frint/pull/39) ([fahad19](https://github.com/fahad19))
 
-## [v0.4.2](https://github.com/Travix-International/frint/tree/v0.4.2) (2016-08-18)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.1...v0.4.2)
-
-**Merged pull requests:**
-
-- Do not load logger in production mode [\#26](https://github.com/Travix-International/frint/pull/26) ([fahad19](https://github.com/fahad19))
-
-## [v0.4.1](https://github.com/Travix-International/frint/tree/v0.4.1) (2016-08-18)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.4.0...v0.4.1)
+## [v0.5.0](https://github.com/frintjs/frint/tree/v0.5.0) (2016-10-31)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.7...v0.5.0)
 
 **Merged pull requests:**
 
-- Support for injecting models [\#25](https://github.com/Travix-International/frint/pull/25) ([alexmiranda](https://github.com/alexmiranda))
-- Add code coverage with Coveralls.io [\#24](https://github.com/Travix-International/frint/pull/24) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- App: new `setRegions` method [\#37](https://github.com/frintjs/frint/pull/37) ([fahad19](https://github.com/fahad19))
+- Tests: for `mapToProps`, `createApp`, and middleware [\#36](https://github.com/frintjs/frint/pull/36) ([fahad19](https://github.com/fahad19))
 
-## [v0.4.0](https://github.com/Travix-International/frint/tree/v0.4.0) (2016-08-15)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.3.0...v0.4.0)
-
-**Merged pull requests:**
-
-- Adds getDOMElement\(\) to createComponent.js [\#22](https://github.com/Travix-International/frint/pull/22) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Pass default merge function to mapToProps [\#21](https://github.com/Travix-International/frint/pull/21) ([alexmiranda](https://github.com/alexmiranda))
-
-## [v0.3.0](https://github.com/Travix-International/frint/tree/v0.3.0) (2016-07-18)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.7...v0.3.0)
+## [v0.4.7](https://github.com/frintjs/frint/tree/v0.4.7) (2016-10-27)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.6...v0.4.7)
 
 **Merged pull requests:**
 
-- Expose PropTypes [\#17](https://github.com/Travix-International/frint/pull/17) ([fahad19](https://github.com/fahad19))
-- Adds the Provider's spec [\#16](https://github.com/Travix-International/frint/pull/16) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Adds the render spec [\#15](https://github.com/Travix-International/frint/pull/15) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Adds the Model.spec.js [\#14](https://github.com/Travix-International/frint/pull/14) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Adds createService spec [\#13](https://github.com/Travix-International/frint/pull/13) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Trigger `initialize\(\)` method in Service and Factory with constructor options [\#35](https://github.com/frintjs/frint/pull/35) ([fahad19](https://github.com/fahad19))
+- Changelogs [\#34](https://github.com/frintjs/frint/pull/34) ([fahad19](https://github.com/fahad19))
 
-## [v0.2.7](https://github.com/Travix-International/frint/tree/v0.2.7) (2016-07-14)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.6...v0.2.7)
+## [v0.4.6](https://github.com/frintjs/frint/tree/v0.4.6) (2016-10-20)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.5...v0.4.6)
 
-**Merged pull requests:**
-
-- Import lodash missing [\#12](https://github.com/Travix-International/frint/pull/12) ([alexmiranda](https://github.com/alexmiranda))
-- Adds the createModel.spec.js [\#8](https://github.com/Travix-International/frint/pull/8) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Improves the createComponent.spec.js [\#6](https://github.com/Travix-International/frint/pull/6) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-- Adds the createFactory spec [\#5](https://github.com/Travix-International/frint/pull/5) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
-
-## [v0.2.6](https://github.com/Travix-International/frint/tree/v0.2.6) (2016-07-12)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.5...v0.2.6)
+## [v0.4.5](https://github.com/frintjs/frint/tree/v0.4.5) (2016-10-20)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.4...v0.4.5)
 
 **Merged pull requests:**
 
-- Optimise region to only re-render when listForRendering changes [\#7](https://github.com/Travix-International/frint/pull/7) ([alexmiranda](https://github.com/alexmiranda))
-- Docs: Guidelines for Pull Requests [\#4](https://github.com/Travix-International/frint/pull/4) ([fahad19](https://github.com/fahad19))
-- Add createComponent spec [\#3](https://github.com/Travix-International/frint/pull/3) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Fix: for passing initial shared state across Widgets [\#33](https://github.com/frintjs/frint/pull/33) ([fahad19](https://github.com/fahad19))
+- Fix mixed ES syntax [\#32](https://github.com/frintjs/frint/pull/32) ([alexmiranda](https://github.com/alexmiranda))
 
-## [v0.2.5](https://github.com/Travix-International/frint/tree/v0.2.5) (2016-07-08)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.4...v0.2.5)
-
-**Merged pull requests:**
-
-- Fix rendering twice issue [\#2](https://github.com/Travix-International/frint/pull/2) ([alexmiranda](https://github.com/alexmiranda))
-
-## [v0.2.4](https://github.com/Travix-International/frint/tree/v0.2.4) (2016-07-07)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.3...v0.2.4)
-
-## [v0.2.3](https://github.com/Travix-International/frint/tree/v0.2.3) (2016-07-07)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.2...v0.2.3)
-
-## [v0.2.2](https://github.com/Travix-International/frint/tree/v0.2.2) (2016-07-07)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.1...v0.2.2)
+## [v0.4.4](https://github.com/frintjs/frint/tree/v0.4.4) (2016-09-01)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.3...v0.4.4)
 
 **Merged pull requests:**
 
-- Apply patch from POC repository [\#1](https://github.com/Travix-International/frint/pull/1) ([alexmiranda](https://github.com/alexmiranda))
+- Fixes Region to differentiate widgets with the same name but different appNames [\#31](https://github.com/frintjs/frint/pull/31) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+-  FAQ section and improvement on createComponent method [\#30](https://github.com/frintjs/frint/pull/30) ([heidilaw4](https://github.com/heidilaw4))
+- TR-11332 Add eslint-config-travix to frint [\#29](https://github.com/frintjs/frint/pull/29) ([markvincze](https://github.com/markvincze))
+- Implement `alex` for linting docs [\#27](https://github.com/frintjs/frint/pull/27) ([fahad19](https://github.com/fahad19))
 
-## [v0.2.1](https://github.com/Travix-International/frint/tree/v0.2.1) (2016-07-07)
-[Full Changelog](https://github.com/Travix-International/frint/compare/v0.2.0...v0.2.1)
+## [v0.4.3](https://github.com/frintjs/frint/tree/v0.4.3) (2016-08-19)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.2...v0.4.3)
 
-## [v0.2.0](https://github.com/Travix-International/frint/tree/v0.2.0) (2016-07-07)
+**Merged pull requests:**
+
+- Make root index.js es5 compatible [\#28](https://github.com/frintjs/frint/pull/28) ([fahad19](https://github.com/fahad19))
+
+## [v0.4.2](https://github.com/frintjs/frint/tree/v0.4.2) (2016-08-18)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.1...v0.4.2)
+
+**Merged pull requests:**
+
+- Do not load logger in production mode [\#26](https://github.com/frintjs/frint/pull/26) ([fahad19](https://github.com/fahad19))
+
+## [v0.4.1](https://github.com/frintjs/frint/tree/v0.4.1) (2016-08-18)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.4.0...v0.4.1)
+
+**Merged pull requests:**
+
+- Support for injecting models [\#25](https://github.com/frintjs/frint/pull/25) ([alexmiranda](https://github.com/alexmiranda))
+- Add code coverage with Coveralls.io [\#24](https://github.com/frintjs/frint/pull/24) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+
+## [v0.4.0](https://github.com/frintjs/frint/tree/v0.4.0) (2016-08-15)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.3.0...v0.4.0)
+
+**Merged pull requests:**
+
+- Adds getDOMElement\(\) to createComponent.js [\#22](https://github.com/frintjs/frint/pull/22) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Pass default merge function to mapToProps [\#21](https://github.com/frintjs/frint/pull/21) ([alexmiranda](https://github.com/alexmiranda))
+
+## [v0.3.0](https://github.com/frintjs/frint/tree/v0.3.0) (2016-07-18)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.7...v0.3.0)
+
+**Merged pull requests:**
+
+- Expose PropTypes [\#17](https://github.com/frintjs/frint/pull/17) ([fahad19](https://github.com/fahad19))
+- Adds the Provider's spec [\#16](https://github.com/frintjs/frint/pull/16) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Adds the render spec [\#15](https://github.com/frintjs/frint/pull/15) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Adds the Model.spec.js [\#14](https://github.com/frintjs/frint/pull/14) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Adds createService spec [\#13](https://github.com/frintjs/frint/pull/13) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+
+## [v0.2.7](https://github.com/frintjs/frint/tree/v0.2.7) (2016-07-14)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.6...v0.2.7)
+
+**Merged pull requests:**
+
+- Import lodash missing [\#12](https://github.com/frintjs/frint/pull/12) ([alexmiranda](https://github.com/alexmiranda))
+- Adds the createModel.spec.js [\#8](https://github.com/frintjs/frint/pull/8) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Improves the createComponent.spec.js [\#6](https://github.com/frintjs/frint/pull/6) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+- Adds the createFactory spec [\#5](https://github.com/frintjs/frint/pull/5) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+
+## [v0.2.6](https://github.com/frintjs/frint/tree/v0.2.6) (2016-07-12)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.5...v0.2.6)
+
+**Merged pull requests:**
+
+- Optimise region to only re-render when listForRendering changes [\#7](https://github.com/frintjs/frint/pull/7) ([alexmiranda](https://github.com/alexmiranda))
+- Docs: Guidelines for Pull Requests [\#4](https://github.com/frintjs/frint/pull/4) ([fahad19](https://github.com/fahad19))
+- Add createComponent spec [\#3](https://github.com/frintjs/frint/pull/3) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
+
+## [v0.2.5](https://github.com/frintjs/frint/tree/v0.2.5) (2016-07-08)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.4...v0.2.5)
+
+**Merged pull requests:**
+
+- Fix rendering twice issue [\#2](https://github.com/frintjs/frint/pull/2) ([alexmiranda](https://github.com/alexmiranda))
+
+## [v0.2.4](https://github.com/frintjs/frint/tree/v0.2.4) (2016-07-07)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.3...v0.2.4)
+
+## [v0.2.3](https://github.com/frintjs/frint/tree/v0.2.3) (2016-07-07)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.2...v0.2.3)
+
+## [v0.2.2](https://github.com/frintjs/frint/tree/v0.2.2) (2016-07-07)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.1...v0.2.2)
+
+**Merged pull requests:**
+
+- Apply patch from POC repository [\#1](https://github.com/frintjs/frint/pull/1) ([alexmiranda](https://github.com/alexmiranda))
+
+## [v0.2.1](https://github.com/frintjs/frint/tree/v0.2.1) (2016-07-07)
+[Full Changelog](https://github.com/frintjs/frint/compare/v0.2.0...v0.2.1)
+
+## [v0.2.0](https://github.com/frintjs/frint/tree/v0.2.0) (2016-07-07)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2017 Travix International
+Copyright (c) 2017 FrintJS Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -52,15 +52,21 @@ The framework is a collection of these packages, which can be composed together 
 | [frint-router]                     | [![frint-router-status]][frint-router-package]                                       | Router services for building Single Page Applications |
 | [frint-router-react]               | [![frint-router-react-status]][frint-router-react-package]                           | React components for building SPAs |
 | [frint-cli]                        | [![frint-cli-status]][frint-cli-package]                                             | CLI runner |
-| [frint-compat]                     | [![frint-compat-status]][frint-compat-package]                                       | Backwards compatibility for older versions |
 | [frint-model]                      | [![frint-model-status]][frint-model-package]                                         | Use `frint-data` instead |
-| **For library developers:**        |                                                                                      |  |
-| [frint-component-utils]            | [![frint-component-utils-status]][frint-component-utils-package]                     | Utils for reactive Components |
-| [frint-component-handlers]         | [![frint-component-handlers-status]][frint-component-handlers-package]               | Handlers for integrating with other rendering libraries |
-| [frint-router-component-handlers]  | [![frint-router-component-handlers-status]][frint-router-component-handlers-package] | Handlers for integrating `frint-router` with other rendering libraries |
-| **Internally used:**               |                                                                                      |  |
-| [frint-test-utils]                 | [![frint-test-utils-status]][frint-test-utils-package]                               | Internally used test utilities |
-| [frint-config]                     | [![frint-config-status]][frint-config-package]                                       | Common config for your Apps |
+
+### For library developers
+
+These packages enable you to create packages integrating FrintJS with other rendering libraries:
+
+* [frint-component-utils]: Utils for reactive Components
+* [frint-component-handlers]: Handlers for integrating with other rendering libraries
+* [frint-router-component-handlers]: Handlers for integrating `frint-router` with other rendering libraries
+
+### Internally used
+
+* [frint-test-utils]: Internally used test utilities
+* [frint-config]: Common config for your Apps
+* [frint-compat]: Backwards compatibility for older versions
 
 [frint]: https://frint.js.org/docs/packages/frint
 [frint-store]: https://frint.js.org/docs/packages/frint-store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # frint
 
-[![npm](https://img.shields.io/npm/v/frint.svg)](https://www.npmjs.com/package/frint) [![Build Status](https://img.shields.io/travis/Travix-International/frint/master.svg)](http://travis-ci.org/Travix-International/frint) [![Coverage](https://img.shields.io/coveralls/Travix-International/frint.svg)](https://coveralls.io/github/Travix-International/frint) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c) [![Join the chat at https://gitter.im/frintjs/frintjs](https://badges.gitter.im/frintjs/frintjs.svg)](https://gitter.im/frintjs/frintjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![npm](https://img.shields.io/npm/v/frint.svg)](https://www.npmjs.com/package/frint) [![Build Status](https://img.shields.io/travis/frintjs/frint/master.svg)](http://travis-ci.org/frintjs/frint) [![Coverage](https://img.shields.io/coveralls/frintjs/frint.svg)](https://coveralls.io/github/frintjs/frint) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c) [![Join the chat at https://gitter.im/frintjs/frintjs](https://badges.gitter.im/frintjs/frintjs.svg)](https://gitter.im/frintjs/frintjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 > The modular JavaScript framework
 
@@ -36,7 +36,7 @@ $ npm install
 $ npm start
 ```
 
-Find more examples [here](https://github.com/Travix-International/frint/tree/master/examples).
+Find more examples [here](https://github.com/frintjs/frint/tree/master/examples).
 
 ## Packages
 
@@ -117,4 +117,4 @@ The framework is a collection of these packages, which can be composed together 
 
 ## License
 
-MIT © [Travix International](http://travix.com)
+MIT © [FrintJS Authors](https://github.com/frintjs/frint/graphs/contributors) and [Travix International](http://travix.com)

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -11,7 +11,7 @@
     "start:server": "live-server ./build --port $(PORT)",
     "start": "npm run build && npm run start:server"
   },
-  "author": "Travix International B.V.",
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "license": "MIT",
   "dependencies": {
     "frint": "^3.3.1",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -10,7 +10,7 @@
     "start:server": "live-server build",
     "start": "npm run build && npm run start:server"
   },
-  "author": "Travix International B.V.",
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "license": "MIT",
   "dependencies": {
     "frint": "^3.3.1",

--- a/examples/multiple-apps/package.json
+++ b/examples/multiple-apps/package.json
@@ -10,7 +10,7 @@
     "serve-only": "live-server build",
     "start": "npm run build && npm run serve-only"
   },
-  "author": "Travix International B.V.",
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "license": "MIT",
   "dependencies": {
     "frint": "^3.3.1",

--- a/examples/router/package.json
+++ b/examples/router/package.json
@@ -11,7 +11,7 @@
     "start:server": "live-server build",
     "start": "npm run build && npm run start:server"
   },
-  "author": "Travix International B.V.",
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "license": "MIT",
   "dependencies": {
     "frint": "^3.3.1",

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   ],
   "version": "4.1.0",
   "changelog": {
-    "repo": "Travix-International/frint",
+    "repo": "frintjs/frint",
     "labels": {
       "bug": "Bug fix",
       "PR": "Pull Requests"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "contributors": [
     {
       "name": "Fahad Ibnay Heylaal",
@@ -39,9 +36,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
-  "homepage": "https://github.com/Travix-International/frint#readme",
+  "homepage": "https://github.com/frintjs/frint#readme",
   "devDependencies": {
     "alex": "^5.0.0",
     "babel-cli": "^6.10.1",

--- a/packages/frint-cli/README.md
+++ b/packages/frint-cli/README.md
@@ -49,7 +49,7 @@ $ mkdir my-directory && cd my-directory
 $ frint init
 ```
 
-To scaffold a certain example, as available in the repository [here](https://github.com/Travix-International/frint/tree/master/examples):
+To scaffold a certain example, as available in the repository [here](https://github.com/frintjs/frint/tree/master/examples):
 
 ```
 $ frint init --example exampleName

--- a/packages/frint-cli/commands/init.js
+++ b/packages/frint-cli/commands/init.js
@@ -18,7 +18,7 @@ Example:
   $ frint init --example kitchensink
 
 You can find list of all available examples here:
-https://github.com/Travix-International/frint/tree/master/examples
+https://github.com/frintjs/frint/tree/master/examples
 `.trim();
 
 module.exports = createApp({
@@ -40,7 +40,7 @@ module.exports = createApp({
           const dir = deps.pwd;
 
           function streamFrintExampleToDir() {
-            request('https://codeload.github.com/Travix-International/frint/tar.gz/master')
+            request('https://codeload.github.com/frintjs/frint/tar.gz/master')
               .on('error', deps.console.error)
               .pipe(tar.x({
                 filter: path => path.indexOf(`frint-master/examples/${example}/`) === 0,

--- a/packages/frint-cli/package.json
+++ b/packages/frint-cli/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "CLI for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-cli",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-cli",
   "bin": {
     "frint": "./bin/frint.js"
   },
@@ -21,12 +21,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint",
     "cli",
@@ -46,7 +43,7 @@
     "memory-fs": "^0.4.1"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT"
 }

--- a/packages/frint-compat/package.json
+++ b/packages/frint-compat/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Backwards compatibility package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-compat",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-compat",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -32,7 +29,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT"
 }

--- a/packages/frint-component-handlers/package.json
+++ b/packages/frint-component-handlers/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Component handlers package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-component-handlers",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-component-handlers",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -38,7 +35,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT"
 }

--- a/packages/frint-component-utils/package.json
+++ b/packages/frint-component-utils/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Component utils package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-component-utils",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-component-utils",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -36,7 +33,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT"
 }

--- a/packages/frint-config/package.json
+++ b/packages/frint-config/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Common configuration for FrintJS applications",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-config",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-config",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -31,7 +28,7 @@
     "cross-env": "^5.0.5"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-data/package.json
+++ b/packages/frint-data/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Reactive data modelling for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-data",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-data",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,17 +18,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "dependencies": {
     "lodash": "^4.13.1",

--- a/packages/frint-model/package.json
+++ b/packages/frint-model/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Model package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-model",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-model",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -36,7 +33,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-react-server/package.json
+++ b/packages/frint-react-server/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Server-side React package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-react-server",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-react-server",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -38,7 +35,7 @@
     "rxjs": "^5.5.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-react/package.json
+++ b/packages/frint-react/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "React package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-react",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-react",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -40,7 +37,7 @@
     "frint-test-utils": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-router-component-handlers/package.json
+++ b/packages/frint-router-component-handlers/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Router component handlers package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-router-component-handlers",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-router-component-handlers",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -37,7 +34,7 @@
     "frint-router": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT"
 }

--- a/packages/frint-router-react/package.json
+++ b/packages/frint-router-react/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "React Components for router in Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-router-react",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-router-react",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -39,7 +36,7 @@
     "frint-test-utils": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-router/package.json
+++ b/packages/frint-router/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Router package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-router",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-router",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -38,7 +35,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-store/package.json
+++ b/packages/frint-store/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Store package for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-store",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-store",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -36,7 +33,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint-test-utils/package.json
+++ b/packages/frint-test-utils/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Test utilities for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-test-utils",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-test-utils",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -35,7 +32,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"

--- a/packages/frint/package.json
+++ b/packages/frint/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "Core plugin for Frint",
   "main": "lib/index.js",
-  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-core",
+  "homepage": "https://github.com/frintjs/frint/tree/master/packages/frint-core",
   "scripts": {
     "lint": "cross-env ../../node_modules/.bin/eslint --color '{src,test}/**/*.js'",
     "transpile": "cross-env ../../node_modules/.bin/babel src --out-dir lib",
@@ -18,12 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
+    "url": "git+https://github.com/frintjs/frint.git"
   },
-  "author": {
-    "name": "Travix International B.V.",
-    "url": "https://travix.com"
-  },
+  "author": "FrintJS Authors (https://github.com/frintjs/frint/graphs/contributors)",
   "keywords": [
     "frint"
   ],
@@ -37,7 +34,7 @@
     "frint-config": "^4.1.0"
   },
   "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
+    "url": "https://github.com/frintjs/frint/issues"
   },
   "license": "MIT",
   "types": "index.d.ts"


### PR DESCRIPTION
Now that the project has moved to its independent organization, I followed what [Bootstrap](https://github.com/twbs/bootstrap) did when they did something similar:

* License is now accredited to both Authors + Organization ([example](https://github.com/twbs/bootstrap/blob/v4-dev/LICENSE#L4))
* Authors info in manifests point to GitHub's contributors page ([example](https://github.com/twbs/bootstrap/blob/v4-dev/package.json#L15))

Closes #355 