### PR TITLE
Removes Coveralls in favor of Codecov.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 after_success:
   - 'npm run cover'
   - './node_modules/.bin/istanbul-combine -d coverage -p summary -r lcov -r html packages/frint*/coverage/coverage*.json'
-  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'
+  - 'npm run codecov'
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # frint
 
-[![npm](https://img.shields.io/npm/v/frint.svg)](https://www.npmjs.com/package/frint) [![Build Status](https://img.shields.io/travis/frintjs/frint/master.svg)](http://travis-ci.org/frintjs/frint) [![Coverage](https://img.shields.io/coveralls/frintjs/frint.svg)](https://coveralls.io/github/frintjs/frint) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c) [![Join the chat at https://gitter.im/frintjs/frintjs](https://badges.gitter.im/frintjs/frintjs.svg)](https://gitter.im/frintjs/frintjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![npm](https://img.shields.io/npm/v/frint.svg)](https://www.npmjs.com/package/frint) [![Build Status](https://img.shields.io/travis/frintjs/frint/master.svg)](http://travis-ci.org/frintjs/frint)
+[![codecov](https://codecov.io/gh/frintjs/frint/branch/master/graph/badge.svg)](https://codecov.io/gh/frintjs/frint) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/2c3431f8-ed10-4ef2-8edb-4873c656497c) [![Join the chat at https://gitter.im/frintjs/frintjs](https://badges.gitter.im/frintjs/frintjs.svg)](https://gitter.im/frintjs/frintjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 > The modular JavaScript framework
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "cover": "lerna run cover",
     "test": "lerna run test",
     "alex": "alex .",
-    "dist": "lerna run dist"
+    "dist": "lerna run dist",
+    "codecov": "codecov"
   },
   "repository": {
     "type": "git",
@@ -48,7 +49,7 @@
     "babel-preset-travix": "^1.1.0",
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
-    "coveralls": "^3.0.0",
+    "codecov": "^3.0.0",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^4.1.0",


### PR DESCRIPTION
# What does this PR do:

* Changes our tool to track coverage through history: removes Coveralls, adds Codecov
* Changes the `README.md`: removes Coveralls badge, adds Codecov

However, Codecov is NOT a one-to-one replacement. We were delegating the _coverage check_ to Coveralls. That's not done anymore on Codecov.

For that, there's the need to create a `.nycrc` defining what is our threshold. Will issue a PR next to this one, as it's not directly related. 

# Where should the reviewer start:
  - Diffs

Note: While this first PR is not merged, it is not possible to do a _comparison with `master`_ since there's no info - on codecov - about `master`.