### PR TITLE
Fix conflict between render and component props in Route component

### DIFF
--- a/packages/frint-router-component-handlers/src/createRouteHandler.js
+++ b/packages/frint-router-component-handlers/src/createRouteHandler.js
@@ -51,7 +51,10 @@ const RouteHandler = {
   },
 
   _calculateComponentState(nextProps, appChanged = false) {
-    if (nextProps.component) {
+    if (nextProps.render) {
+      // render
+      this.setData('component', null);
+    } else if (nextProps.component) {
       // component
       this._destroyRouteApp();
 

--- a/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
+++ b/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
@@ -94,6 +94,55 @@ describe('frint-router-component-handlers › createRouteHandler', function () {
     });
   });
 
+  describe('RouteHandler functions properly with render() throughout lifecycle', function () {
+    const router = new MemoryRouterService();
+
+    const component = createComponent();
+    const componentToRender = createComponent();
+
+    component.props = {
+      path: '/',
+      exact: true,
+      render: () => null
+    };
+
+    const handler = createRouteHandler(
+      ComponentHandler,
+      createTestAppInstance(router),
+      component
+    );
+
+    router.push('/');
+
+    it('initially component data is set to null', function () {
+      component.data = handler.getInitialData();
+
+      expect(component.data.component).to.be.null;
+    });
+
+    it('when component prop is set, component data keeps null value', function () {
+      component.props.component = componentToRender;
+      handler.propsChange(component.props, false, false, false);
+
+      expect(component.data.component).to.be.null;
+    });
+
+    it('when render() prop is removed, component data is equal to component prop', function () {
+      component.props.render = undefined;
+      handler.propsChange(component.props, false, false, false);
+
+      expect(component.data.component).to.equal(componentToRender);
+    });
+
+    it('when render() prop is set and component prop removed, component data equals to null', function () {
+      component.props.component = undefined;
+      component.props.render = () => null;
+      handler.propsChange(component.props, false, false, false);
+
+      expect(component.data.component).to.be.null;
+    });
+  });
+
   describe('RouteHandler functions properly with computedMatch throughout lifecycle', function () {
     const router = new MemoryRouterService();
 

--- a/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
+++ b/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
@@ -103,7 +103,10 @@ describe('frint-router-component-handlers › createRouteHandler', function () {
     component.props = {
       path: '/',
       exact: true,
-      render: () => null
+      render: function () {
+        /* istanbul ignore next */
+        return null;
+      }
     };
 
     const handler = createRouteHandler(


### PR DESCRIPTION
This commit fixes following bug. Whenever `<Route />` instance had `component` prop, and then props change to having `render` prop and not having `component` prop, the `component` would still get rendered (ignoring `render` prop), because if was saved in state and `component` state has priority over `render` prop.

Example code where it was breaking (while switching between routes):

```js
<Switch>
  <Route path="/one" component={OneComponent} />
  <Route path="/two" render={() => <AnotherComponent />} />
</Switch>
```

Now it's fixed by setting `component` state to `null` whenever `render` prop is present.