### PR TITLE
frint: handle App lifecycle events without overriding options

### DIFF
--- a/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
+++ b/packages/frint-router-component-handlers/src/createRouteHandler.spec.js
@@ -72,7 +72,7 @@ describe('frint-router-component-handlers › createRouteHandler', function () {
 
       handler.propsChange(component.props, false, false, true);
 
-      expect(component.data.component).to.equal(appComponent);
+      expect(component.data.component).to.deep.equal(appComponent);
     });
 
     it('when path prop change and propsChange() is called, matched data is changed', function () {

--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -447,4 +447,68 @@ describe('frint  › App', function () {
       app.instantiateApp('blah');
     }).to.throw(/No app found with name 'blah'/);
   });
+
+  it('can accept additional lifecycle callbacks for Root Apps while instantiating, without overriding', function () {
+    let counter = 0;
+
+    const Root = createApp({
+      name: 'RootApp',
+      initialize() {
+        counter += 1;
+      },
+    });
+
+    new Root({
+      initialize() {
+        counter += 1;
+      },
+    });
+
+    expect(counter).to.equal(2);
+  });
+
+  it('can accept additional lifecycle callbacks for Child Apps while registering, without overriding', function () {
+    let counter = 0;
+
+    const Root = createApp({
+      name: 'RootApp',
+    });
+    const ChildApp = createApp({
+      name: 'ChildApp',
+      initialize() {
+        counter += 1;
+      },
+    });
+
+    const app = new Root();
+    app.registerApp(ChildApp, {
+      initialize() {
+        counter += 1;
+      },
+    });
+
+    expect(counter).to.equal(2);
+  });
+
+  it('can update providers at lifecycle level', function () {
+    const Root = createApp({
+      name: 'RootApp',
+      providers: [
+        {
+          name: 'foo',
+          useValue: 'original foo',
+        },
+      ],
+      initialize() {
+        const foo = this.get('foo');
+        this.container.register({
+          name: 'foo',
+          useValue: `${foo} [updated]`,
+        });
+      }
+    });
+
+    const app = new Root();
+    expect(app.get('foo')).to.equal('original foo [updated]');
+  });
 });

--- a/packages/frint/src/createApp.js
+++ b/packages/frint/src/createApp.js
@@ -2,13 +2,33 @@ import merge from 'lodash/merge';
 
 import BaseApp from './App';
 
+function mergeOptions(createAppOptions, constructorOptions) {
+  const mergedOptions = merge({}, createAppOptions, constructorOptions);
+
+  // keep lifecycle methods from both
+  // `createApp(options)` and `new App(options)`
+  [
+    'initialize',
+    'beforeDestroy',
+  ].forEach((cbName) => {
+    if (
+      typeof createAppOptions[cbName] === 'function' &&
+      typeof constructorOptions[cbName] === 'function'
+    ) {
+      mergedOptions[cbName] = function lifecycleCb() {
+        createAppOptions[cbName]();
+        constructorOptions[cbName]();
+      };
+    }
+  });
+
+  return mergedOptions;
+}
+
 export default function createApp(options = {}) {
   class App extends BaseApp {
     constructor(opts = {}) {
-      super(merge(
-        options,
-        opts
-      ));
+      super(mergeOptions(options, opts));
     }
   }
 


### PR DESCRIPTION
## What's done

When defining and instantiating Apps, the lifecycle methods (`initialize` and `beforeDestroy`) will not be overridden any more.

This means, the methods you pass when creating an App, and also intantiating the App will both trigger.

## Usage

```js
import { createApp } from 'frint';

const RootApp = createApp({
  name: 'RootApp',
  initialize() {
    console.log('defined when creating App class');
  },
});

const app = new RootApp({
  initialize() {
    console.log('defined when instantiating the App');
  }
});
```

The above code will print two logs in this order:

```
defined when creating App class
defined when instantiating the App
```

## What value does it bring?

The API will now allow us to wrap Child Apps' components with ease in a custom bundler level, as mentioned in #376.

We can now do something like:

```js
window.app.registerApp(ChildApp, {
  initialize() {
    const existingComponent = this.get('component');
    const wrappedComponent = wrapItWithErrorBoundaryAndLogTheError(existingComponent);
    this.container.register({
      name: 'component',
      useValue: wrappedComponent,
    });
  },
});
```

You can see the examples in tests in the diff.