### PR TITLE
Ensure proper `this` context in lifecycle callbacks

### DIFF
--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -511,4 +511,35 @@ describe('frint  › App', function () {
     const app = new Root();
     expect(app.get('foo')).to.equal('original foo [updated]');
   });
+
+  it('can access and update providers from lifecycle callback defined while instantiating', function () {
+    const Root = createApp({
+      name: 'RootApp',
+      providers: [
+        {
+          name: 'foo',
+          useValue: 'original foo',
+        },
+      ],
+      initialize() {
+        const foo = this.get('foo');
+        this.container.register({
+          name: 'foo',
+          useValue: `${foo} [updatedFromCreateApp]`,
+        });
+      }
+    });
+
+    const app = new Root({
+      initialize() {
+        const foo = this.get('foo');
+        this.container.register({
+          name: 'foo',
+          useValue: `${foo} [updatedFromInstantiation]`,
+        });
+      }
+    });
+
+    expect(app.get('foo')).to.equal('original foo [updatedFromCreateApp] [updatedFromInstantiation]');
+  });
 });

--- a/packages/frint/src/createApp.js
+++ b/packages/frint/src/createApp.js
@@ -16,8 +16,8 @@ function mergeOptions(createAppOptions, constructorOptions) {
       typeof constructorOptions[cbName] === 'function'
     ) {
       mergedOptions[cbName] = function lifecycleCb() {
-        createAppOptions[cbName]();
-        constructorOptions[cbName]();
+        createAppOptions[cbName].call(this);
+        constructorOptions[cbName].call(this);
       };
     }
   });


### PR DESCRIPTION
When `initialize` is defined both at the time of creation and instantiation of the apps, they didn't have proper `this` context so it couldn't for example access providers with `this.get(...)`. This PR fixes the issue.