### PR TITLE
frint-react: start props stream with default props synchronously

### DIFF
--- a/packages/frint-component-utils/src/streamProps.js
+++ b/packages/frint-component-utils/src/streamProps.js
@@ -8,6 +8,7 @@ import isObservable from './isObservable';
 
 class Streamer {
   constructor(defaults = {}) {
+    this._defaults = defaults;
     this._observables = [
       of$(defaults),
     ];
@@ -89,13 +90,17 @@ class Streamer {
   }
 
   get$() {
-    return merge$(...this._observables)
+    const result$ = merge$(...this._observables)
       .pipe(scan$((props, emitted) => {
         return {
           ...props,
           ...emitted,
         };
       }));
+
+    result$.defaultProps = this._defaults;
+
+    return result$;
   }
 }
 

--- a/packages/frint-component-utils/src/streamProps.spec.js
+++ b/packages/frint-component-utils/src/streamProps.spec.js
@@ -16,14 +16,18 @@ describe('frint-react › streamProps', function () {
       key: 'value',
     });
 
-    streamer.get$()
-      .subscribe(function (props) {
-        expect(props).to.deep.equal({
-          key: 'value',
-        });
+    const props$ = streamer.get$();
+    expect(props$.defaultProps).to.deep.equal({
+      key: 'value',
+    });
 
-        done();
+    props$.subscribe(function (props) {
+      expect(props).to.deep.equal({
+        key: 'value',
       });
+
+      done();
+    });
   });
 
   it('streams plain object, by merging with default', function (done) {

--- a/packages/frint-react-server/src/renderToString.spec.js
+++ b/packages/frint-react-server/src/renderToString.spec.js
@@ -1,11 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, func-names, react/prop-types */
 /* global describe, it */
 import React from 'react';
-import { of as of$ } from 'rxjs/observable/of';
 import { expect } from 'chai';
 
 import { createApp } from 'frint';
-import { observe } from 'frint-react';
+import { observe, streamProps } from 'frint-react';
 
 import renderToString from './renderToString';
 
@@ -49,9 +48,12 @@ describe('frint-react-server › renderToString', function () {
     }
 
     const ObservedTestComponent = observe(function (app) {
-      return of$({
+      const defaultProps = {
         name: app.getName(),
-      });
+      };
+
+      return streamProps(defaultProps)
+        .get$();
     })(TestComponent);
 
     const TestApp = createApp({

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -71,7 +71,7 @@ describe('frint-react › components › observe', function () {
     }
 
     const ObservedComponent = observe(function (app, props$) {
-      return merge$(
+      const generatedProps$ = merge$(
         of$({ name: app.getName() }),
         props$.pipe(map$(parentProps => ({ parentProps })))
       )
@@ -81,6 +81,12 @@ describe('frint-react › components › observe', function () {
             ...emitted,
           };
         }));
+
+      generatedProps$.defaultProps = {
+        name: app.getName(),
+      };
+
+      return generatedProps$;
     })(Component);
 
     class ParentComponent extends React.Component {


### PR DESCRIPTION
Closes #390 

## What's done

### In `frint-react`:

When an Observable is returned from the `observe` higher-order component, it will now check if it has a static `defaultProps` property, and set that as default props to start with.

### In `frint-component-utils`

The `streamProps` helper function will now ultimately generate an Observable with `defaultProps` static property, if it received any via `streamProps(defaultProps)`.

## Usage

As of our last release, you need to take care of the props based on what environment you are in:

```js
import { observe, streamProps } from 'frint-react';

function MyComponent(props) {
  return '';
}

export default observe(function () {
  const defaultProps = { foo: 'foo value here' };

  if (process.env.BABEL_ENV === 'server') {
    // handle it synchronously
    return defaultProps;
  }

  // Observable
  return streamProps(defaultProps)
    .set(...)
    .get$();
});
```

With this PR, you can now just do this directly in your code without having to worry about server-side rendering:

```js
import { observe, streamProps } from 'frint-react';

function MyComponent(props) {
  return '';
}

export default observe(function () {
  return streamProps({ foo: 'foo value here' })
    .set(...)
    .get$();
});
```

Less to worry about as a developer.

