### PR TITLE
frint-store: interop with all reactive libraries

### DIFF
--- a/packages/frint-store/package.json
+++ b/packages/frint-store/package.json
@@ -26,7 +26,8 @@
   ],
   "dependencies": {
     "lodash": "^4.13.1",
-    "rxjs": "^5.5.0"
+    "rxjs": "^5.5.0",
+    "symbol-observable": "^1.1.0"
   },
   "devDependencies": {
     "cross-env": "^5.0.5",


### PR DESCRIPTION
**Note**: NOT a breaking change

## What's done

`frint-store` now supports interoperability with other reactive libraries, following the TC39 proposal here: https://github.com/tc39/proposal-observable#observablefrom

## Usage

As of latest release, we can get our state stream as an Observable like this:

```js
const state$ = store.getState$();
```

With this PR, we now adhere to common standards as per the TC39 proposal, and can get the state stream by doing:

```js
const state$ = Observable.from(store);
```

The `store.getState$()` still remains in the API, and uses `from(store)` internally.

## Why

This will enable us to build more generic tools without having to know too much about the internal APIs of `frint-store`.

More will follow in #391 