### PR TITLE
frint-data: support Date as a type

### DIFF
--- a/packages/frint-data/README.md
+++ b/packages/frint-data/README.md
@@ -526,6 +526,18 @@ const Todo = createModel({
 });
 ```
 
+### Types.date
+
+> Types.date
+
+```js
+const Todo = createModel({
+  schema: {
+    createdAt: Types.date
+  }
+});
+```
+
 ### Types.number
 
 > Types.number

--- a/packages/frint-data/src/Types.js
+++ b/packages/frint-data/src/Types.js
@@ -49,6 +49,26 @@ Types.number = chain(function (value) {
   return value;
 });
 
+Types.date = chain(function (value) {
+  if (typeof value === 'undefined') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsedDate = Date.parse(value);
+
+    if (!isNaN(parsedDate)) {
+      return new Date(parsedDate);
+    }
+  }
+
+  if (!(value instanceof Date)) {
+    throw new TypesError('value is not a valid date object');
+  }
+
+  return value;
+});
+
 Types.array = chain(function (value) {
   if (typeof value === 'undefined') {
     return value;

--- a/packages/frint-data/src/Types.spec.js
+++ b/packages/frint-data/src/Types.spec.js
@@ -109,6 +109,45 @@ describe('frint-data › Types', function () {
     });
   });
 
+  describe('Types :: date', function () {
+    it('accepts undefined unless required', function () {
+      const type = Types.date;
+
+      expect(type()).to.be.an('undefined');
+      expect(() => type.isRequired()).to.throw('value is not defined');
+    });
+
+    it('accepts date object as value', function () {
+      const type = Types.date;
+
+      const date = new Date();
+      expect(type(date)).to.equal(date);
+    });
+
+    it('rejects non date object values', function () {
+      const type = Types.date;
+
+      expect(() => type(0)).to.throw(/value is not a valid date/);
+      expect(() => type(null)).to.throw(/value is not a valid date/);
+      expect(() => type('hello world')).to.throw(/value is not a valid date/);
+      expect(() => type(() => {})).to.throw(/value is not a valid date/);
+    });
+
+    it('checks for required values', function () {
+      const type = Types.date.isRequired;
+
+      expect(() => type()).to.throw(/value is not defined/);
+    });
+
+    it('allows empty values when default is set', function () {
+      const date = new Date();
+      const type = Types.date.defaults(date);
+
+      expect(type()).to.equal(date);
+      expect(() => type(123)).to.throw(/value is not a valid date/);
+    });
+  });
+
   describe('Types :: collection', function () {
     it('accepts undefined unless required', function () {
       const type = Types.collection;

--- a/packages/frint-data/src/createModel.js
+++ b/packages/frint-data/src/createModel.js
@@ -62,6 +62,14 @@ export default function createModel(options = {}) {
                 return convertToJS(v);
               }
 
+              // for supporting Date objects
+              if (
+                v &&
+                typeof v.toISOString === 'function'
+              ) {
+                return v.toISOString();
+              }
+
               return v;
             });
           }

--- a/packages/frint-data/src/createModel.js
+++ b/packages/frint-data/src/createModel.js
@@ -65,7 +65,7 @@ export default function createModel(options = {}) {
               // for supporting Date objects
               if (
                 v &&
-                typeof v.toISOString === 'function'
+                v instanceof Date
               ) {
                 return v.toISOString();
               }

--- a/packages/frint-data/src/createModel.spec.js
+++ b/packages/frint-data/src/createModel.spec.js
@@ -643,6 +643,45 @@ describe('frint-data › createModel', function () {
     expect(person.name).to.equal('Updated by initialize');
   });
 
+  it('can work with date objects', function () {
+    const CalendarEvent = createModel({
+      schema: {
+        start: Types.date,
+        end: Types.date,
+        created: Types.date,
+        updated: Types.date,
+      },
+    });
+
+    const d1 = new Date();
+    const d2 = 'Mon Dec 25 2017 12:00:00 GMT+0000';
+    const d3 = undefined;
+    const d4 = d1.toString();
+
+    const calendarEvent = new CalendarEvent({
+      start: d1,
+      end: d2,
+      created: d3,
+      updated: d4,
+    });
+
+    expect(isModel(calendarEvent)).to.equal(true);
+
+    // model values
+    expect(calendarEvent.start).to.deep.equal(d1);
+    expect(calendarEvent.end).to.be.an.instanceof(Date);
+    expect(calendarEvent.created).to.equal(undefined);
+    expect(calendarEvent.updated).to.be.an.instanceof(Date);
+
+    // plain values
+    const calendarEventObj = calendarEvent.toJS();
+    const pattern = /^[0-9]{4}[-][0-9]{2}[-][0-9]{2}T(.*)$/;
+    expect(calendarEventObj.start).to.match(pattern);
+    expect(calendarEventObj.end).to.match(pattern);
+    expect(calendarEventObj.created).to.equal(undefined);
+    expect(calendarEventObj.updated).to.match(pattern);
+  });
+
   describe('Model :: get()', function () {
     it('gets value by path from self', function (done) {
       const Person = createModel({


### PR DESCRIPTION
## What's done

Added a new `Types.date` in the API.

## Usage

```js
import { createModel, Types } from 'frint-data';

const Todo = createModel({
  schema: {
    createdAt: Types.date,
  },
});
```

Can be instantiated with either Date objects, or a string that `Date.parse()` can understand:

```js
const todo1 = new Todo({
  createdAt: new Date(),
});

const todo2 = new Todo({
  createdAt: 'Thu Dec 28 2017 08:04:56 GMT+0000 (UTC)',
});
```

When using `model.toJS()`, it will return the value as a string according to `date.toISOString()`:

```js
const createdAt = someTodo.toJS().createdAt; // `2017-12-28T16:29:26.258Z`
```