### PR TITLE
Fix the signature of the function getApps$ in the d.ts

### DIFF
--- a/packages/frint/index.d.ts
+++ b/packages/frint/index.d.ts
@@ -56,7 +56,7 @@ export class App {
 
     getAppOnceAvailable$(name: string, region?: string, regionKey?: string): Observable<App>;
 
-    getApps$<T extends RegisteredApp>(regionName: string): Observable<T>;
+    getApps$<T extends RegisteredApp>(regionName?: string): Observable<T[]>;
 
     getContainer(): Container;
 


### PR DESCRIPTION
I started experimenting with migrating one of the packages to TypeScript, and discovered some incorrect signatures in the `d.ts` typings (there might be more) in the `getApps$` function:

 - the `regionName` argument should be optional
 - the `Observable` in the result is returning an array, not just a single app

Without the fix we get the following errors:

![image](https://user-images.githubusercontent.com/1122274/34443968-06fa001c-eccb-11e7-8ed2-f58806d064bb.png)

and

![image](https://user-images.githubusercontent.com/1122274/34443980-0ee2bf8a-eccb-11e7-8268-00dff2b67591.png)