### PR TITLE
frint: Support listening to Child App registrations from providers

### DIFF
--- a/packages/frint/src/App.js
+++ b/packages/frint/src/App.js
@@ -60,6 +60,10 @@ function App(opts = {}) {
     throw new Error('Must provide `name` in options');
   }
 
+  // children - create Observable if root
+  this._appsCollection = [];
+  this._apps$ = new BehaviorSubject(this._appsCollection);
+
   // container
   const Container = createContainer([
     { name: this.options.providerNames.app, useDefinedValue: this },
@@ -77,10 +81,6 @@ function App(opts = {}) {
   this.options.providers.forEach((provider) => {
     this.container.register(provider);
   });
-
-  // children - create Observable if root
-  this._appsCollection = [];
-  this._apps$ = new BehaviorSubject(this._appsCollection);
 
   this.options.initialize.bind(this)();
 }


### PR DESCRIPTION
## What's done

From providers, it was not possible to listen to Child App registrations before, because the dependencies were resolved BEFORE defining the Subject for apps list.

The Subject has been moved above now, without causing any unintended side-effects.

## Usage

```js
const Root = createApp({
  name: 'RootApp',
  providers: [
    {
      name: '__EXEC__',
      useFactory({ app }) {
        // before, it was not possible to call `app.getApps$()` here
        app.getApps$().subscribe(x => console.log(x);
      },
      deps: ['app'],
    },
  ],
});
```