### PR TITLE
frint-react: improve display name of observed components

### DIFF
--- a/packages/frint-react/src/components/observe.js
+++ b/packages/frint-react/src/components/observe.js
@@ -11,9 +11,13 @@ import isObservable from '../isObservable';
 
 export default function observe(fn) {
   return (Component) => {
+    const componentName = (typeof Component.displayName !== 'undefined')
+      ? Component.displayName
+      : Component.name;
+
     class WrappedComponent extends React.Component {
-      static displayName = (typeof Component.displayName !== 'undefined')
-        ? `observe(${Component.displayName})`
+      static displayName = (typeof componentName !== 'undefined')
+        ? `observe(${componentName})`
         : 'observe';
 
       static contextTypes = {

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -22,6 +22,31 @@ describe('frint-react › components › observe', function () {
     expect(observe).to.be.a('function');
   });
 
+  it('generates Component with display name if WrappedComponent has display name', function () {
+    function Component() {
+      return (
+        <p id="text">Hello World</p>
+      );
+    }
+    Component.displayName = 'NamedComponent';
+
+    const ObservedComponent = observe()(Component);
+
+    expect(ObservedComponent.displayName).to.equal('observe(NamedComponent)');
+  });
+
+  it('generates Component with display name if WrappedComponent has no display name', function () {
+    function UnnamedComponent() {
+      return (
+        <p id="text">Hello World</p>
+      );
+    }
+
+    const ObservedComponent = observe()(UnnamedComponent);
+
+    expect(ObservedComponent.displayName).to.equal('observe(UnnamedComponent)');
+  });
+
   it('generates Component bound to observable for props, without app in context', function () {
     function Component({ counter }) {
       return (

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -23,11 +23,7 @@ describe('frint-react › components › observe', function () {
   });
 
   it('generates Component with display name if WrappedComponent has display name', function () {
-    function Component() {
-      return (
-        <p id="text">Hello World</p>
-      );
-    }
+    function Component() {}
     Component.displayName = 'NamedComponent';
 
     const ObservedComponent = observe()(Component);
@@ -36,11 +32,7 @@ describe('frint-react › components › observe', function () {
   });
 
   it('generates Component with display name if WrappedComponent has no display name', function () {
-    function UnnamedComponent() {
-      return (
-        <p id="text">Hello World</p>
-      );
-    }
+    function UnnamedComponent() {}
 
     const ObservedComponent = observe()(UnnamedComponent);
 


### PR DESCRIPTION
## What's done

Add `name` as a fallback for `displayName` when defining the display name of an observed component.

## Why

Usually, we don't need to set `displayName` explicitly because it's inferred from the name of the function or class that defines the component. However, this inferred value may be set as a `name` class property instead, so we should consider this case as well.

This change follows the convention for [wrapping the display name of a wrapped component](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging) from React docs.