### PR TITLE
frint-di: Fix Container.get() return type

### DIFF
--- a/packages/frint-cli/src/bin/frint.ts
+++ b/packages/frint-cli/src/bin/frint.ts
@@ -66,7 +66,7 @@ function run() {
     return console.log('Command not available.');
   }
 
-  return commandApp.get<FrintCliProvider>('execute')();
+  return (commandApp.get('execute') as FrintCliProvider)();
 }
 
 run();

--- a/packages/frint-cli/src/commands/help.spec.ts
+++ b/packages/frint-cli/src/commands/help.spec.ts
@@ -22,7 +22,7 @@ describe('frint-cli › commands › help', () => {
     const commandApp = rootApp.getAppInstance('help');
     const fakeConsole = rootApp.get('console');
 
-    commandApp.get<FrintCliProvider>('execute')();
+    commandApp.get('execute')();
 
     expect(fakeConsole.errors.length).to.equal(1);
     expect(fakeConsole.errors[0]).to.contain('Must provide a command name');
@@ -50,7 +50,7 @@ describe('frint-cli › commands › help', () => {
     const commandApp = rootApp.getAppInstance('help');
     const fakeConsole = rootApp.get('console');
 
-    commandApp.get<FrintCliProvider>('execute')();
+    commandApp.get('execute')();
 
     expect(fakeConsole.logs.length).to.equal(1);
   });

--- a/packages/frint-cli/src/commands/version.spec.ts
+++ b/packages/frint-cli/src/commands/version.spec.ts
@@ -39,7 +39,7 @@ describe('frint-cli › commands › version', () => {
       '{"version": "1.2.3"}'
     );
 
-    commandApp.get<FrintCliProvider>('execute')();
+    commandApp.get('execute')();
 
     expect(fakeConsole.logs.length).to.equal(1);
     expect(fakeConsole.logs[0]).to.contain('v1.2.3');

--- a/packages/frint-di/index.d.ts
+++ b/packages/frint-di/index.d.ts
@@ -24,6 +24,6 @@ export interface Constructor<T> {
   new(): T;
 }
 
-export function createContainer(providers: Provider[], options: ContainerOptions): Constructor<Container>;
+export function createContainer(providers: Provider[], options?: ContainerOptions): Constructor<Container>;
 
 export function resolveContainer<T>(Container: Constructor<T>): T;

--- a/packages/frint-di/index.d.ts
+++ b/packages/frint-di/index.d.ts
@@ -13,7 +13,7 @@ export interface Provider {
 export interface Container {
   getDeps(container: Provider): any;
   register(container: Provider): any;
-  get<T extends Provider>(name: string): T;
+  get(name: string): any;
 }
 
 export interface ContainerOptions {

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -193,8 +193,8 @@ export class App {
     });
   }
 
-  public get<T extends FrintProvider>(providerName) {
-    const value = this.container.get<T>(providerName);
+  public get(providerName) {
+    const value = this.container.get(providerName);
 
     if (typeof value !== 'undefined') {
       return value;


### PR DESCRIPTION
In practice `Container.get()` returns instance of a provider, which can be anything.

`Provider` interface is a definition of provider, not instance. Therefore typing was incorrect.

Make `options` optional in createContainer() definition