### PR TITLE
Define type of Container.get() return value with generic

### DIFF
--- a/packages/frint-cli/src/bin/frint.ts
+++ b/packages/frint-cli/src/bin/frint.ts
@@ -10,6 +10,7 @@ import VersionCommand from '../commands/version';
 
 import { FrintCliProvider } from '../FrintCliProvider';
 import { App } from '../index';
+import { FrintConfig } from '../providers';
 
 const app = new App();
 
@@ -19,7 +20,7 @@ app.registerApp(NewCommand);
 app.registerApp(VersionCommand);
 
 const command = app.get('command');
-const config = app.get('config');
+const config = app.get<FrintConfig>('config');
 
 // register custom plugins
 if (Array.isArray(config.plugins)) {
@@ -66,7 +67,7 @@ function run() {
     return console.log('Command not available.');
   }
 
-  return (commandApp.get('execute') as FrintCliProvider)();
+  return commandApp.get<FrintCliProvider>('execute')();
 }
 
 run();

--- a/packages/frint-cli/src/commands/help.spec.ts
+++ b/packages/frint-cli/src/commands/help.spec.ts
@@ -4,6 +4,7 @@ import { App } from 'frint';
 import { FrintCliProvider } from '../FrintCliProvider';
 import createRootApp from '../index.mock';
 import HelpCommand from './help';
+import { FakeConsole } from '../providers.mock';
 
 describe('frint-cli › commands › help', () => {
   it('is a Frint App', () => {
@@ -20,9 +21,9 @@ describe('frint-cli › commands › help', () => {
     const rootApp = new RootApp();
     rootApp.registerApp(HelpCommand);
     const commandApp = rootApp.getAppInstance('help');
-    const fakeConsole = rootApp.get('console');
+    const fakeConsole = rootApp.get<FakeConsole>('console');
 
-    commandApp.get('execute')();
+    commandApp.get<FrintCliProvider>('execute')();
 
     expect(fakeConsole.errors.length).to.equal(1);
     expect(fakeConsole.errors[0]).to.contain('Must provide a command name');
@@ -48,9 +49,9 @@ describe('frint-cli › commands › help', () => {
     const rootApp = new RootApp();
     rootApp.registerApp(HelpCommand);
     const commandApp = rootApp.getAppInstance('help');
-    const fakeConsole = rootApp.get('console');
+    const fakeConsole = rootApp.get<FakeConsole>('console');
 
-    commandApp.get('execute')();
+    commandApp.get<FrintCliProvider>('execute')();
 
     expect(fakeConsole.logs.length).to.equal(1);
   });

--- a/packages/frint-cli/src/commands/help.spec.ts
+++ b/packages/frint-cli/src/commands/help.spec.ts
@@ -3,8 +3,8 @@ import { App } from 'frint';
 
 import { FrintCliProvider } from '../FrintCliProvider';
 import createRootApp from '../index.mock';
-import HelpCommand from './help';
 import { FakeConsole } from '../providers.mock';
+import HelpCommand from './help';
 
 describe('frint-cli › commands › help', () => {
   it('is a Frint App', () => {

--- a/packages/frint-cli/src/commands/version.spec.ts
+++ b/packages/frint-cli/src/commands/version.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { App } from 'frint';
-import * as path from 'path';
 import * as MemoryFs from 'memory-fs';
+import * as path from 'path';
 
 import { FrintCliProvider } from '../FrintCliProvider';
 import createRootApp from '../index.mock';
-import VersionCommand from './version';
 import { FakeConsole } from '../providers.mock';
+import VersionCommand from './version';
 
 describe('frint-cli › commands › version', () => {
   it('is a Frint App', () => {

--- a/packages/frint-cli/src/commands/version.spec.ts
+++ b/packages/frint-cli/src/commands/version.spec.ts
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 import { App } from 'frint';
 import * as path from 'path';
+import * as MemoryFs from 'memory-fs';
 
 import { FrintCliProvider } from '../FrintCliProvider';
 import createRootApp from '../index.mock';
 import VersionCommand from './version';
+import { FakeConsole } from '../providers.mock';
 
 describe('frint-cli › commands › version', () => {
   it('is a Frint App', () => {
@@ -29,17 +31,17 @@ describe('frint-cli › commands › version', () => {
     const rootApp = new RootApp();
     rootApp.registerApp(VersionCommand);
     const commandApp = rootApp.getAppInstance('version');
-    const fakeConsole = rootApp.get('console');
+    const fakeConsole = rootApp.get<FakeConsole>('console');
 
-    rootApp.get('fs').mkdirpSync(
+    rootApp.get<MemoryFs>('fs').mkdirpSync(
       path.resolve(`${__dirname}/../../`)
     );
-    rootApp.get('fs').writeFileSync(
+    rootApp.get<MemoryFs>('fs').writeFileSync(
       path.resolve(`${__dirname}/../../package.json`),
       '{"version": "1.2.3"}'
     );
 
-    commandApp.get('execute')();
+    commandApp.get<FrintCliProvider>('execute')();
 
     expect(fakeConsole.logs.length).to.equal(1);
     expect(fakeConsole.logs[0]).to.contain('v1.2.3');

--- a/packages/frint-cli/src/providers.mock.ts
+++ b/packages/frint-cli/src/providers.mock.ts
@@ -1,5 +1,12 @@
 import * as MemoryFs from 'memory-fs';
 
+export interface FakeConsole {
+  errors: string[],
+  logs: string[],
+  log: (message: string) => void,
+  error: (message: string) => void,
+}
+
 const fs = new MemoryFs();
 
 export default [
@@ -36,7 +43,7 @@ export default [
     name: 'console',
     cascade: true,
     useFactory: function useFactory() {
-      const fakeConsole = {
+      const fakeConsole: FakeConsole = {
         errors: [],
         logs: [],
 

--- a/packages/frint-cli/src/providers.mock.ts
+++ b/packages/frint-cli/src/providers.mock.ts
@@ -1,10 +1,10 @@
 import * as MemoryFs from 'memory-fs';
 
 export interface FakeConsole {
-  errors: string[],
-  logs: string[],
-  log: (message: string) => void,
-  error: (message: string) => void,
+  errors: string[];
+  logs: string[];
+  log: (message: string) => void;
+  error: (message: string) => void;
 }
 
 const fs = new MemoryFs();

--- a/packages/frint-cli/src/providers.ts
+++ b/packages/frint-cli/src/providers.ts
@@ -3,7 +3,7 @@ import clone = require('lodash/clone');
 import * as path from 'path';
 import { argv } from 'yargs';
 
-interface FrintConfig {
+export interface FrintConfig {
   plugins: string[];
 }
 

--- a/packages/frint-di/index.d.ts
+++ b/packages/frint-di/index.d.ts
@@ -13,7 +13,7 @@ export interface Provider {
 export interface Container {
   getDeps(container: Provider): any;
   register(container: Provider): any;
-  get(name: string): any;
+  get<T>(name: string): T;
 }
 
 export interface ContainerOptions {

--- a/packages/frint/src/App.spec.ts
+++ b/packages/frint/src/App.spec.ts
@@ -98,7 +98,7 @@ describe('frint  › App', () => {
       ],
     });
 
-    expect(app.get('foo').getValue()).to.equal('fooValue');
+    expect(app.get<Foo>('foo').getValue()).to.equal('fooValue');
   });
 
   it('registers providers with dependencies', () => {
@@ -140,7 +140,7 @@ describe('frint  › App', () => {
 
     expect(app.get('foo')).to.equal('fooValue');
     expect(app.get('bar')).to.equal('barValue, fooValue');
-    expect(app.get('baz').getValue()).to.equal('bazValue, fooValue, barValue, fooValue');
+    expect(app.get<Baz>('baz').getValue()).to.equal('bazValue, fooValue, barValue, fooValue');
   });
 
   it('returns services from Root that are cascaded', () => {
@@ -198,7 +198,7 @@ describe('frint  › App', () => {
     const app = root.getAppInstance('App1');
     // expect(app.get('serviceA')).to.equal('serviceA');
     expect(app.get('serviceB')).to.equal('serviceB');
-    expect(app.get('serviceC').getValue()).to.equal('serviceC');
+    expect(app.get<ServiceC>('serviceC').getValue()).to.equal('serviceC');
     expect(app.get('serviceD')).to.equal(null);
     expect(app.get('serviceE')).to.equal('serviceE');
 

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -193,8 +193,8 @@ export class App {
     });
   }
 
-  public get(providerName) {
-    const value = this.container.get(providerName);
+  public get<T>(providerName) {
+    const value = this.container.get<T>(providerName);
 
     if (typeof value !== 'undefined') {
       return value;


### PR DESCRIPTION
Following suggestion by @markvincze, I've changed Container.get() signature from `get(name: string): any;` to `get<T>(name: string): T;`.

This not only allows to leverage type safety of TypeScript, but requires to use it.

Previously Container type was optional

```ts
const console: Console = container.get('console');
console.log()
```

Now if you don't specify `<Console>` it'll default to `{}` (empty object type) and `console.log()` won't compile. This is not ideal but unfortunately I don't know the way to require generic type in TS.  Nevertheless it achieves the goal of making type required, because without using the type you pretty much cannot use the value received from the container.

```ts
const console = container.get<Console>('console');
console.log() // works
```

```ts
const console = container.get('console');
console.log() // error TS2339: Property 'log' does not exist on type '{}'
```