### PR TITLE
[#406][#412] Fix 3 frintTypescript Errors

### DIFF
--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -217,7 +217,7 @@ export class App {
       }));
   }
 
-  public registerApp(appClass: AppClass, opts: RegisterAppOptions = {}) {
+  public registerApp(appClass: AppClass = App, opts: RegisterAppOptions = {}) {
     const options = {
       multi: false,
       ...opts,

--- a/packages/frint/src/index.ts
+++ b/packages/frint/src/index.ts
@@ -1,2 +1,2 @@
 export { default as createApp } from './createApp';
-export { App, FrintProvider } from './App';
+export { App, AppClass, FrintProvider } from './App';


### PR DESCRIPTION
The three errors were encountered when moving the exemplar Multiple-Apps project to Typescript.

In file: `core/app/index.ts`
```Typescript
import { createApp, AppClass } from 'frint';

import RootComponent from '../components/Root';

export default createApp({
  name: 'MiskApp',
  providers: [
    {
      name: 'component',
      useValue: RootComponent,
    },
  ],
});
```

Error 1
---

Within VS Code, the following Typescript error was raised
```
Default export of the module has or is using private name 'AppClass'.
```

And at compile time, this error is raised.
```
ERROR in [at-loader] ./src/core/app/index.ts:1:21
    TS2305: Module '"/Users/aparadi/Development/misk-admin/main/node_modules/frint/lib/index"' has no exported member 'AppClass'.
```

Based on the first part of this error, the issue is found to be that Typescript requires knowledge of the interface for `AppClass` within the exported `App` class. Since `AppClass` is a private/unexported class, there is an error. The proposed solution is to export `AppClass` along with `App, FrintProvider` in `frint/index.ts`.

```Typescript
export { default as createApp } from './createApp';
export { App, AppClass, FrintProvider } from './App';

```

Then, in client apps in `core/app/index.ts`, `AppClass` can be imported along with `createApp` from `'frint'` without error.
```Typescript
import { createApp, AppClass } from 'frint';

import RootComponent from '../components/Root';

export default createApp({
  name: 'App',
  providers: [
    {
      name: 'component',
      useValue: RootComponent,
    },
  ],
});
```

Error 2
---
Within `core/index.ts` for new client apps, adjustments can be made to prevent the need to use `<any>` to eliminate Typescript errors.

`core/index.ts`
```Typescript
import { App as FrintApp } from 'frint';
import { render } from 'frint-react';

import App from './app';

const apps: FrintApp[]= (<any>window).app || [];
const app: FrintApp = (<any>window).app = new App();
(<any>app).push = (options: any) => app.registerApp(...options);
apps.forEach((<any>app).push);

render(app, document.getElementById('root'));
```

Adjustments that could/have be(en) made include:
- [x] Importing `FrintApp` allows Typescript to take full advantage of the full class when verifying class types `apps` and `app`.
- [ ] Adding a push interface/function to the App class in `frint/App.ts` to eliminate the `any` override
- [ ] Adding an interface for Window that includes `.app`

If these two additional adjustments would like to be pursued, I will go ahead and fix them.

Error 3
---

One error that took an especially long time to solve was in regards to `app.registerApp(...options);` which had the following message:
```
ERROR in [at-loader] ./src/core/index.ts:9:37
    TS2556: Expected 1-2 arguments, but got 0 or more.
```

The issue seemed to be confusion with matching the rest param operator (ie. `...options`) which has no minimum parameters requirement against the compiled function definition in `frint/App.d.ts` which has 1 required parameter (`appClass`) and 1 optional (`opts?`).

Currently, the following in `frint/App.ts`...
```Typescript
public registerApp(appClass: AppClass, opts: RegisterAppOptions = {}) {...}
```
...compiles down to a mandatory `appClass` parameter in `frint/lib/App.d.ts`
```Typescript
registerApp(appClass: AppClass, opts?: RegisterAppOptions): void;
```

To fix this, I propose providing an initializer for `appClass` so that when compiled down there is no mismatch of number of required parameters. Thus the following in `frint/App.ts`

```Typescript
public registerApp(appClass: AppClass = App, opts: RegisterAppOptions = {}) {...}
```

The alternative method is to simply use `any` type as below but I preferred not to rely on that as it eliminates many of the benefits of Typescript.
```Typescript
(<any>app).registerApp(...options);
```

tl;dr
---
- A few changes suggested and implemented to reduce the need to use `(<any>app)` or other blunt ways to quiet Typescript compile errors.
- 2 suggested but unimplemented changes for Error 2 which I can work on if requested.
- Open to any suggestions and feedback!