### PR TITLE
frint: Expose class methods on the app instance level

### DIFF
--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -275,6 +275,7 @@ The base App class.
 
 1. `options` (`Object`)
     * `options.name`: (`String` [required]): Name of your App.
+    * `options.methods`: (`Object` [optional]): Object with the methods your App exposes on the instance level.
     * `options.initialize`: (`Function` [optional]): Called when App is constructed.
     * `options.beforeDestroy`: (`Function` [optional]): Called when App is about to be destroyed.
     * `options.providers`: (`Array` [optional]): Array of provider objects.
@@ -312,6 +313,14 @@ The `App` instance
 #### Returns
 
 `String`: The App's name.
+
+### app.getMethods
+
+> app.getMethods()
+
+#### Returns
+
+`Object`: The App's methods.
 
 ### app.getRootApp
 

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -314,14 +314,6 @@ The `App` instance
 
 `String`: The App's name.
 
-### app.getMethods
-
-> app.getMethods()
-
-#### Returns
-
-`Object`: The App's methods.
-
 ### app.getRootApp
 
 > app.getRootApp()

--- a/packages/frint/src/App.spec.ts
+++ b/packages/frint/src/App.spec.ts
@@ -13,12 +13,38 @@ describe('frint  › App', () => {
     }).to.throw(/Must provide `name` in options/);
   });
 
-  it('gets option value', () => {
+  it('gets name option value', () => {
     const app = new App({
       name: 'MyApp',
     });
 
     expect(app.getName()).to.equal('MyApp');
+  });
+
+  it('gets methods option value', () => {
+    const methods = {
+      foo() {},
+    }
+
+    const app = new App({
+      name: 'MyApp',
+      methods,
+    });
+
+    expect(app.getMethods()).to.deep.equal(methods);
+  });
+
+  it('exposes methods as class properties', () => {
+    const methods = {
+      foo() { return 'foo'; },
+    }
+
+    const app = new App({
+      name: 'MyApp',
+      methods,
+    });
+
+    expect(app.foo()).to.equal('foo');
   });
 
   it('gets parent and root app', () => {

--- a/packages/frint/src/App.spec.ts
+++ b/packages/frint/src/App.spec.ts
@@ -48,6 +48,20 @@ describe('frint  › App', () => {
     expect(app.foo()).to.equal('foo');
   });
 
+  it('does not overwrite app properties or methods with options methods', () => {
+    const methods = {
+      // tslint:disable-next-line:no-empty
+      getName() {},
+    };
+
+    expect(() => (
+      new App({
+        name: 'MyApp',
+        methods,
+      })
+    )).to.throw(/Cannot overwrite app's `getName` property or method with options method/);
+  });
+
   it('gets parent and root app', () => {
     const rootApp = new App({
       name: 'RootApp',

--- a/packages/frint/src/App.spec.ts
+++ b/packages/frint/src/App.spec.ts
@@ -21,20 +21,6 @@ describe('frint  › App', () => {
     expect(app.getName()).to.equal('MyApp');
   });
 
-  it('gets methods option value', () => {
-    const methods = {
-      foo() { return 'foo'; },
-    };
-
-    const app = new App({
-      name: 'MyApp',
-      methods,
-    });
-
-    expect(app.getMethods()).to.deep.equal(methods);
-    expect(app.getMethods().foo()).to.equal('foo');
-  });
-
   it('exposes methods as class properties', () => {
     const methods = {
       foo() { return 'foo'; },

--- a/packages/frint/src/App.spec.ts
+++ b/packages/frint/src/App.spec.ts
@@ -23,8 +23,8 @@ describe('frint  › App', () => {
 
   it('gets methods option value', () => {
     const methods = {
-      foo() {},
-    }
+      foo() { return 'foo'; },
+    };
 
     const app = new App({
       name: 'MyApp',
@@ -32,12 +32,13 @@ describe('frint  › App', () => {
     });
 
     expect(app.getMethods()).to.deep.equal(methods);
+    expect(app.getMethods().foo()).to.equal('foo');
   });
 
   it('exposes methods as class properties', () => {
     const methods = {
       foo() { return 'foo'; },
-    }
+    };
 
     const app = new App({
       name: 'MyApp',

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -93,7 +93,7 @@ export interface AppClass {
 }
 
 export class App {
-  [property: string]: any;
+  [field: string]: any;
   public container: Container;
   private options: AppOptions;
   private _appsCollection: AppRegistration[];
@@ -128,6 +128,10 @@ export class App {
       const method = this.options.methods[methodName];
 
       if (typeof method === 'function') {
+        if (this[methodName] !== undefined) {
+          throw new Error(`Cannot overwrite app's \`${methodName}\` property or method with options method.`);
+        }
+
         this[methodName] = method.bind(this);
       }
     });

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -32,6 +32,10 @@ function makeInstanceKey(region = null, regionKey = null, multi = false) {
   return key;
 }
 
+export interface Methods {
+  [key: string]: () => any;
+}
+
 export interface ProviderNames {
   component: string;
   container: string;
@@ -75,6 +79,7 @@ export interface AppRegistration {
 
 export interface AppOptions {
   name?: string;
+  methods?: Methods;
   parentApp?: App;
   providers?: FrintProvider[];
   providerNames?: ProviderNames;
@@ -88,6 +93,7 @@ export interface AppClass {
 }
 
 export class App {
+  [property: string]: any;
   public container: Container;
   private options: AppOptions;
   private _appsCollection: AppRegistration[];
@@ -96,6 +102,7 @@ export class App {
   constructor(opts: AppOptions) {
     this.options = {
       name: null,
+      methods: {},
       parentApp: null,
       providers: [],
 
@@ -115,6 +122,15 @@ export class App {
     if (!this.options.name) {
       throw new Error('Must provide `name` in options');
     }
+
+    // expose methods as class properties
+    Object.keys(this.options.methods).forEach(methodName => {
+      const method = this.options.methods[methodName];
+
+      if (typeof method === 'function') {
+        this[methodName] = method.bind(this);
+      }
+    });
 
     // children - create Observable if root
     this._appsCollection = [];
@@ -181,6 +197,10 @@ export class App {
 
   public getName() {
     return this.getOption('name');
+  }
+
+  public getMethods() {
+    return this.getOption('methods');
   }
 
   public getProviders() {

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -93,7 +93,7 @@ export interface AppClass {
 }
 
 export class App {
-  [field: string]: any;
+  [method: string]: any;
   public container: Container;
   private options: AppOptions;
   private _appsCollection: AppRegistration[];

--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -203,10 +203,6 @@ export class App {
     return this.getOption('name');
   }
 
-  public getMethods() {
-    return this.getOption('methods');
-  }
-
   public getProviders() {
     return this.options.providers;
   }


### PR DESCRIPTION
## What's done

- Add optional `methods` (`Object`) property to `AppOptions`, which has its properties added to the app's `this` object.
- Add `app.getMethods` method which returns the app's `methods` object.

## Why

Allow access to public methods directly from the app instance, besides the `options` property.

Closes #426.