### PR TITLE
frint-react: Fix typo in `children` prop type

### DIFF
--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -8,7 +8,7 @@ import getMountableComponent from './getMountableComponent';
 
 export default class Region extends React.Component {
   static propTypes = {
-    children: PropTypes.function,
+    children: PropTypes.func,
     className: PropTypes.string,
     name: PropTypes.string.isRequired,
     uniqueKey: PropTypes.string,


### PR DESCRIPTION
## What's done

Fix typo in `Region`'s `children` prop type.

## Why

When render props were implemented, the `Region`'s `children` prop type was mistakenly assigned to `PropTypes.function` instead of `PropTypes.func`, which causes the following warning:

> Warning: Failed prop type: Region: prop type `children` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.