### PR TITLE
Fixes #437 - Add generic type for Frint Methods interface

### DIFF
--- a/packages/frint/src/App.ts
+++ b/packages/frint/src/App.ts
@@ -33,7 +33,7 @@ function makeInstanceKey(region = null, regionKey = null, multi = false) {
 }
 
 export interface Methods {
-  [key: string]: () => any;
+  [key: string]: (...args: any[]) => any;
 }
 
 export interface ProviderNames {


### PR DESCRIPTION
Extend Method Interface to receive arguments in methods.

Ex: 
```typescript
const exampleApp = createApp({
  name: 'Example',
  methods: {
    sum: (a: number, b: number): number =>  a + b
  }
});
```