### PR TITLE
Used ES6 syntax to use React's { Component } instead of referencing it as React.Component

### DIFF
--- a/examples/counter/core/components/Root.js
+++ b/examples/counter/core/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe, streamProps } from 'frint-react';
 
 import {
@@ -6,7 +6,7 @@ import {
   decrementCounter
 } from '../actions/counter';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     return (
       <div className="container">

--- a/examples/kitchensink/app-color/components/Root.js
+++ b/examples/kitchensink/app-color/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe } from 'frint-react';
 import { Observable } from 'rxjs/Observable';
 import { concatMap } from 'rxjs/operator/concatMap';
@@ -18,7 +18,7 @@ import {
   CHANGE_COLOR_ASYNC
 } from '../constants';
 
-class Root extends React.Component {
+class Root extends Component {
   static propTypes = {
     color: PropTypes.string,
     counter: PropTypes.number,

--- a/examples/kitchensink/app-counter/components/Root.js
+++ b/examples/kitchensink/app-counter/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe, streamProps } from 'frint-react';
 import PropTypes from 'prop-types';
 
@@ -7,7 +7,7 @@ import {
   decrementCounter
 } from '../actions/counter';
 
-class Root extends React.Component {
+class Root extends Component {
   static propTypes = {
     color: PropTypes.string,
     counter: PropTypes.number,

--- a/examples/kitchensink/app-reversed/components/Root.js
+++ b/examples/kitchensink/app-reversed/components/Root.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe } from 'frint-react';
 import { map } from 'rxjs/operator/map';
 import { scan } from 'rxjs/operator/scan';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     return (
       <div>

--- a/examples/kitchensink/app-todos/components/Item.js
+++ b/examples/kitchensink/app-todos/components/Item.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe, streamProps, Region } from 'frint-react';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { removeTodo, updateTodo } from '../actions/todos';
 
-class Item extends React.Component {
+class Item extends Component {
   render() {
     const { todo } = this.props;
 

--- a/examples/kitchensink/app-todos/components/Root.js
+++ b/examples/kitchensink/app-todos/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe } from 'frint-react';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
@@ -8,7 +8,7 @@ import { scan } from 'rxjs/operator/scan';
 import { addTodo } from '../actions/todos';
 import Item from './Item';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     return (
       <div>

--- a/examples/kitchensink/core/components/Root.js
+++ b/examples/kitchensink/core/components/Root.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Region, observe } from 'frint-react';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     return (
       <div className="container">

--- a/examples/multiple-apps/app-bar/components/Root.js
+++ b/examples/multiple-apps/app-bar/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe, streamProps } from 'frint-react';
 
 import {
@@ -9,7 +9,7 @@ import {
   RED_COLOR
 } from '../constants';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     const codeStyle = {
       color: this.props.color,

--- a/examples/multiple-apps/app-foo/components/Root.js
+++ b/examples/multiple-apps/app-foo/components/Root.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { observe, streamProps } from 'frint-react';
 
 import {
@@ -6,7 +6,7 @@ import {
   decrementCounter
 } from '../actions/counter';
 
-class Root extends React.Component {
+class Root extends Component {
   render() {
     const codeStyle = {
       color: this.props.color,

--- a/examples/multiple-apps/core/components/Root.js
+++ b/examples/multiple-apps/core/components/Root.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Region } from 'frint-react';
 
-export default class Root extends React.Component {
+export default class Root extends Component {
   render() {
     return (
       <div className="container">


### PR DESCRIPTION
Instead of referencing React.Component we can use ES6 to pull Component from React by saying :

`import React, { Component } from 'react';`

And, use `Component` directly instead of `React.Component` 
:cookie: 